### PR TITLE
Feat/add normalize function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add `normalize` method to `Path` and `Utf8Path` to support resolving `.` and
+  `..` across Windows and Unix encodings
+* Add `is_parent` and `is_current` methods to `Component` and `Utf8Component`
+  traits with implementations for both Unix and Windows component
+  implementations
+
 ## [0.3.2] - 2023-03-27
 
 * Fix implementation of `Display` for `Utf8Path` to use underlying str

--- a/src/common/non_utf8/components/component.rs
+++ b/src/common/non_utf8/components/component.rs
@@ -38,6 +38,31 @@ pub trait Component<'a>:
     /// * `UnixComponent::Normal(b"here.txt")` - `is_normal() == true`
     fn is_normal(&self) -> bool;
 
+    /// Returns true if this component represents a relative representation of a parent directory
+    ///
+    /// # Examples
+    ///
+    /// `/my/../path/./here.txt` has the components on Unix of
+    ///
+    /// * `UnixComponent::RootDir` - `is_parent() == false`
+    /// * `UnixComponent::ParentDir` - `is_parent() == true`
+    /// * `UnixComponent::CurDir` - `is_parent() == false`
+    /// * `UnixComponent::Normal("here.txt")` - `is_parent() == false`
+    fn is_parent(&self) -> bool;
+
+    /// Returns true if this component represents a relative representation of the current
+    /// directory
+    ///
+    /// # Examples
+    ///
+    /// `/my/../path/./here.txt` has the components on Unix of
+    ///
+    /// * `UnixComponent::RootDir` - `is_current() == false`
+    /// * `UnixComponent::ParentDir` - `is_current() == false`
+    /// * `UnixComponent::CurDir` - `is_current() == true`
+    /// * `UnixComponent::Normal("here.txt")` - `is_current() == false`
+    fn is_current(&self) -> bool;
+
     /// Returns size of component in bytes
     fn len(&self) -> usize;
 

--- a/src/common/non_utf8/path.rs
+++ b/src/common/non_utf8/path.rs
@@ -537,17 +537,60 @@ where
 
     /// Returns an owned [`PathBuf`] by resolving `..` and `.` segments.
     ///
-    /// When multiple, sequential path segment separation characters are found (e.g. `/` on POSIX
-    /// or either `\` or `/` on Windows), they are replaced by a single instance of the
-    /// platform-specific path segment separator (`/` on POSIX and `\` on Windows).
+    /// When multiple, sequential path segment separation characters are found (e.g. `/` for Unix
+    /// and either `\` or `/` on Windows), they are replaced by a single instance of the
+    /// platform-specific path segment separator (`/` on Unix and `\` on Windows).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Path, PathBuf, UnixEncoding};
+    ///
+    /// // NOTE: A path cannot be created on its own without a defined encoding
+    /// assert_eq!(
+    ///     Path::<UnixEncoding>::new("foo/bar//baz/./asdf/quux/..").normalize(),
+    ///     PathBuf::from("foo/bar/baz/asdf"),
+    /// );
+    /// ```
+    ///
+    /// When starting with a root directory, any `..` segment whose parent is the root directory
+    /// will be filtered out:
+    ///
+    /// ```
+    /// use typed_path::{Path, PathBuf, UnixEncoding};
+    ///
+    /// // NOTE: A path cannot be created on its own without a defined encoding
+    /// assert_eq!(
+    ///     Path::<UnixEncoding>::new("/../foo").normalize(),
+    ///     PathBuf::from("/foo"),
+    /// );
+    /// ```
+    ///
+    /// If any `..` is left unresolved as the path is relative and no parent is found, it is
+    /// discarded:
+    ///
+    /// ```
+    /// use typed_path::{Path, PathBuf, UnixEncoding, WindowsEncoding};
+    ///
+    /// assert_eq!(
+    ///     Path::<UnixEncoding>::new("../foo/..").normalize(),
+    ///     PathBuf::from(""),
+    /// );
+    ///
+    /// // Windows prefixes also count this way, but the prefix remains
+    /// assert_eq!(
+    ///     Path::<WindowsEncoding>::new(r"C:..\foo\..").normalize(),
+    ///     PathBuf::from(r"C:"),
+    /// );
+    /// ```
     pub fn normalize(&self) -> PathBuf<T> {
         let mut components = Vec::new();
         for component in self.components() {
-            if component.is_root() || component.is_normal() {
+            if !component.is_current() && !component.is_parent() {
                 components.push(component);
             } else if component.is_parent() {
                 if let Some(last) = components.last() {
-                    if !last.is_root() {
+                    if last.is_normal() {
                         components.pop();
                     }
                 }

--- a/src/common/utf8/components/component.rs
+++ b/src/common/utf8/components/component.rs
@@ -38,6 +38,31 @@ pub trait Utf8Component<'a>:
     /// * `UnixComponent::Normal("here.txt")` - `is_normal() == true`
     fn is_normal(&self) -> bool;
 
+    /// Returns true if this component represents a relative representation of a parent directory
+    ///
+    /// # Examples
+    ///
+    /// `/my/../path/./here.txt` has the components on Unix of
+    ///
+    /// * `UnixComponent::RootDir` - `is_parent() == false`
+    /// * `UnixComponent::ParentDir` - `is_parent() == true`
+    /// * `UnixComponent::CurDir` - `is_parent() == false`
+    /// * `UnixComponent::Normal("here.txt")` - `is_parent() == false`
+    fn is_parent(&self) -> bool;
+
+    /// Returns true if this component represents a relative representation of the current
+    /// directory
+    ///
+    /// # Examples
+    ///
+    /// `/my/../path/./here.txt` has the components on Unix of
+    ///
+    /// * `UnixComponent::RootDir` - `is_current() == false`
+    /// * `UnixComponent::ParentDir` - `is_current() == false`
+    /// * `UnixComponent::CurDir` - `is_current() == true`
+    /// * `UnixComponent::Normal("here.txt")` - `is_current() == false`
+    fn is_current(&self) -> bool;
+
     /// Returns size of component in bytes
     fn len(&self) -> usize;
 

--- a/src/common/utf8/path.rs
+++ b/src/common/utf8/path.rs
@@ -487,6 +487,34 @@ where
             .and_then(|(before, after)| before.and(after))
     }
 
+    /// Returns an owned [`Utf8PathBuf`] by resolving `..` and `.` segments.
+    ///
+    /// When multiple, sequential path segment separation characters are found (e.g. `/` on POSIX
+    /// or either `\` or `/` on Windows), they are replaced by a single instance of the
+    /// platform-specific path segment separator (`/` on POSIX and `\` on Windows).
+    pub fn normalize(&self) -> Utf8PathBuf<T> {
+        let mut components = Vec::new();
+        for component in self.components() {
+            if component.is_root() || component.is_normal() {
+                components.push(component);
+            } else if component.is_parent() {
+                if let Some(last) = components.last() {
+                    if !last.is_root() {
+                        components.pop();
+                    }
+                }
+            }
+        }
+
+        let mut path = Utf8PathBuf::<T>::new();
+
+        for component in components {
+            path.push(component.as_str());
+        }
+
+        path
+    }
+
     /// Creates an owned [`Utf8PathBuf`] with `path` adjoined to `self`.
     ///
     /// See [`Utf8PathBuf::push`] for more details on what it means to adjoin a path.

--- a/src/unix/non_utf8/components/component.rs
+++ b/src/unix/non_utf8/components/component.rs
@@ -88,6 +88,42 @@ impl<'a> Component<'a> for UnixComponent<'a> {
         matches!(self, Self::Normal(_))
     }
 
+    /// Returns true if is a parent directory component
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Component, unix::UnixComponent};
+    /// use std::convert::TryFrom;
+    ///
+    /// let parent = UnixComponent::try_from("..").unwrap();
+    /// assert!(parent.is_parent());
+    ///
+    /// let root_dir = UnixComponent::try_from("/").unwrap();
+    /// assert!(!root_dir.is_parent());
+    /// ```
+    fn is_parent(&self) -> bool {
+        matches!(self, Self::ParentDir)
+    }
+
+    /// Returns true if is the current directory component
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Component, unix::UnixComponent};
+    /// use std::convert::TryFrom;
+    ///
+    /// let current = UnixComponent::try_from(".").unwrap();
+    /// assert!(current.is_current());
+    ///
+    /// let root_dir = UnixComponent::try_from("/").unwrap();
+    /// assert!(!root_dir.is_current());
+    /// ```
+    fn is_current(&self) -> bool {
+        matches!(self, Self::CurDir)
+    }
+
     fn len(&self) -> usize {
         self.as_bytes().len()
     }

--- a/src/unix/utf8/components/component.rs
+++ b/src/unix/utf8/components/component.rs
@@ -167,6 +167,42 @@ impl<'a> Utf8Component<'a> for Utf8UnixComponent<'a> {
         matches!(self, Self::Normal(_))
     }
 
+    /// Returns true if is a parent directory component
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Utf8Component, unix::Utf8UnixComponent};
+    /// use std::convert::TryFrom;
+    ///
+    /// let parent = Utf8UnixComponent::try_from("..").unwrap();
+    /// assert!(parent.is_parent());
+    ///
+    /// let root_dir = Utf8UnixComponent::try_from("/").unwrap();
+    /// assert!(!root_dir.is_parent());
+    /// ```
+    fn is_parent(&self) -> bool {
+        matches!(self, Self::ParentDir)
+    }
+
+    /// Returns true if is the current directory component
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Utf8Component, unix::Utf8UnixComponent};
+    /// use std::convert::TryFrom;
+    ///
+    /// let current = Utf8UnixComponent::try_from(".").unwrap();
+    /// assert!(current.is_current());
+    ///
+    /// let root_dir = Utf8UnixComponent::try_from("/").unwrap();
+    /// assert!(!root_dir.is_current());
+    /// ```
+    fn is_current(&self) -> bool {
+        matches!(self, Self::CurDir)
+    }
+
     fn len(&self) -> usize {
         self.as_str().len()
     }

--- a/src/windows/non_utf8/components/component.rs
+++ b/src/windows/non_utf8/components/component.rs
@@ -134,6 +134,42 @@ impl<'a> Component<'a> for WindowsComponent<'a> {
         matches!(self, Self::Normal(_))
     }
 
+    /// Returns true if is a parent directory component
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Component, windows::WindowsComponent};
+    /// use std::convert::TryFrom;
+    ///
+    /// let parent = WindowsComponent::try_from("..").unwrap();
+    /// assert!(parent.is_parent());
+    ///
+    /// let root_dir = WindowsComponent::try_from(r"\").unwrap();
+    /// assert!(!root_dir.is_parent());
+    /// ```
+    fn is_parent(&self) -> bool {
+        matches!(self, Self::ParentDir)
+    }
+
+    /// Returns true if is the current directory component
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Component, windows::WindowsComponent};
+    /// use std::convert::TryFrom;
+    ///
+    /// let current = WindowsComponent::try_from(".").unwrap();
+    /// assert!(current.is_current());
+    ///
+    /// let root_dir = WindowsComponent::try_from(r"\").unwrap();
+    /// assert!(!root_dir.is_current());
+    /// ```
+    fn is_current(&self) -> bool {
+        matches!(self, Self::CurDir)
+    }
+
     fn len(&self) -> usize {
         self.as_bytes().len()
     }

--- a/src/windows/utf8/components/component.rs
+++ b/src/windows/utf8/components/component.rs
@@ -215,6 +215,42 @@ impl<'a> Utf8Component<'a> for Utf8WindowsComponent<'a> {
         matches!(self, Self::Normal(_))
     }
 
+    /// Returns true if is a parent directory component
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Utf8Component, windows::Utf8WindowsComponent};
+    /// use std::convert::TryFrom;
+    ///
+    /// let parent = Utf8WindowsComponent::try_from("..").unwrap();
+    /// assert!(parent.is_parent());
+    ///
+    /// let root_dir = Utf8WindowsComponent::try_from(r"\").unwrap();
+    /// assert!(!root_dir.is_parent());
+    /// ```
+    fn is_parent(&self) -> bool {
+        matches!(self, Self::ParentDir)
+    }
+
+    /// Returns true if is the current directory component
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Utf8Component, windows::Utf8WindowsComponent};
+    /// use std::convert::TryFrom;
+    ///
+    /// let current = Utf8WindowsComponent::try_from(".").unwrap();
+    /// assert!(current.is_current());
+    ///
+    /// let root_dir = Utf8WindowsComponent::try_from(r"\").unwrap();
+    /// assert!(!root_dir.is_current());
+    /// ```
+    fn is_current(&self) -> bool {
+        matches!(self, Self::CurDir)
+    }
+
     fn len(&self) -> usize {
         self.as_str().len()
     }


### PR DESCRIPTION
Adds a new `normalize` method to both `Path` and `Utf8Path` alongside `is_parent` and `is_current` methods on `Component` and `Utf8Component` traits.

The `normalize` method will resolve `.` and `..` with `..` being removed if the path is relative and there is nothing else to resolve.

This can potentially be used to address #8 by determining if an existing path is relative and - if so - prepending the current working directory as a path and then normalizing it. The trick is figuring out how to take a platform-specific path and convert it to the proper encoding, or just not caring about that.