### PR TITLE
Feat/add to encoding function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add `is_parent` and `is_current` methods to `Component` and `Utf8Component`
   traits with implementations for both Unix and Windows component
   implementations
+* Add `root`, `parent`, and `current` static methods to `Component` and
+  `Utf8Component` traits to support creating the instances from generics
+* Add `absolutize` to both `normalize` the path and - in the case of relative
+  paths - prefix the path with the current working directory
+* Add `to_encoding` to `Path` and `Utf8Path` support converting between the
+  Unix and Windows encoding types
 
 ## [0.3.2] - 2023-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2023-08-23
+
 * Add `normalize` method to `Path` and `Utf8Path` to support resolving `.` and
   `..` across Windows and Unix encodings
 * Add `is_parent` and `is_current` methods to `Component` and `Utf8Component`
@@ -57,7 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial release of the library!
 
-[Unreleased]: https://github.com/chipsenkbeil/typed-path/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/chipsenkbeil/typed-path/compare/v0.4.0...HEAD
+[0.3.2]: https://github.com/chipsenkbeil/typed-path/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/chipsenkbeil/typed-path/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/chipsenkbeil/typed-path/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/chipsenkbeil/typed-path/compare/v0.2.1...v0.3.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "typed-path"
 description = "Provides typed variants of Path and PathBuf for Unix and Windows"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 authors = ["Chip Senkbeil <chip@senkbeil.org>"]
 categories = ["development-tools", "filesystem", "os"]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and Windows.
 
 ```toml
 [dependencies]
-typed-path = "0.3"
+typed-path = "0.4"
 ```
 
 ## Why?

--- a/src/common/non_utf8/components/component.rs
+++ b/src/common/non_utf8/components/component.rs
@@ -70,4 +70,13 @@ pub trait Component<'a>:
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    /// Returns a root [`Component`].
+    fn root() -> Self;
+
+    /// Returns a parent directory [`Component`].
+    fn parent() -> Self;
+
+    /// Returns a current directory [`Component`].
+    fn current() -> Self;
 }

--- a/src/common/non_utf8/path.rs
+++ b/src/common/non_utf8/path.rs
@@ -858,17 +858,17 @@ where
             for component in self.components() {
                 if component.is_root() {
                     path.push(<
-                        <<U as Encoding>::Components as Components>::Component 
+                        <<U as Encoding>::Components as Components>::Component
                         as Component
                     >::root().as_bytes());
                 } else if component.is_current() {
                     path.push(<
-                        <<U as Encoding>::Components as Components>::Component 
+                        <<U as Encoding>::Components as Components>::Component
                         as Component
                     >::current().as_bytes());
                 } else if component.is_parent() {
                     path.push(<
-                        <<U as Encoding>::Components as Components>::Component 
+                        <<U as Encoding>::Components as Components>::Component
                         as Component
                     >::parent().as_bytes());
                 } else {

--- a/src/common/non_utf8/path.rs
+++ b/src/common/non_utf8/path.rs
@@ -811,6 +811,14 @@ where
 
     /// Converts to a different encoding, returning a new [`PathBuf`].
     ///
+    /// # Note
+    ///
+    /// As part of the process of converting between encodings, the path will need to be rebuilt.
+    /// This involves [`pushing`] each component, which may result in differences in the resulting
+    /// path such as resolving `.` and `..` early or other unexpected side effects.
+    ///
+    /// [`pushing`]: PathBuf::push
+    ///
     /// # Examples
     ///
     /// ```

--- a/src/common/non_utf8/path.rs
+++ b/src/common/non_utf8/path.rs
@@ -849,11 +849,20 @@ where
             // to the appropriate type, otherwise we pass along as-is
             for component in self.components() {
                 if component.is_root() {
-                    path.push(<<<U as Encoding>::Components as Components>::Component as Component>::root().as_bytes());
+                    path.push(<
+                        <<U as Encoding>::Components as Components>::Component 
+                        as Component
+                    >::root().as_bytes());
                 } else if component.is_current() {
-                    path.push(<<<U as Encoding>::Components as Components>::Component as Component>::current().as_bytes());
+                    path.push(<
+                        <<U as Encoding>::Components as Components>::Component 
+                        as Component
+                    >::current().as_bytes());
                 } else if component.is_parent() {
-                    path.push(<<<U as Encoding>::Components as Components>::Component as Component>::parent().as_bytes());
+                    path.push(<
+                        <<U as Encoding>::Components as Components>::Component 
+                        as Component
+                    >::parent().as_bytes());
                 } else {
                     path.push(component.as_bytes());
                 }

--- a/src/common/non_utf8/path.rs
+++ b/src/common/non_utf8/path.rs
@@ -2,11 +2,12 @@ mod display;
 
 pub use display::Display;
 
-use crate::{Ancestors, Component, Components, Encoding, Iter, PathBuf, StripPrefixError};
+use crate::{utils, Ancestors, Component, Components, Encoding, Iter, PathBuf, StripPrefixError};
 use std::{
     borrow::{Cow, ToOwned},
     cmp, fmt,
     hash::{Hash, Hasher},
+    io,
     marker::PhantomData,
     rc::Rc,
     sync::Arc,
@@ -606,6 +607,42 @@ where
         path
     }
 
+    /// Converts a path to an absolute form by [`normalizing`] the path, returning a
+    /// [`PathBuf`].
+    ///
+    /// In the case that the path is relative, the current working directory is prepended prior to
+    /// normalizing.
+    ///
+    /// [`normalizing`]: Path::normalize
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{utils, Path, UnixEncoding};
+    ///
+    /// // With an absolute path, it is just normalized
+    /// let path = Path::<UnixEncoding>::new("/a/b/../c/./d");
+    /// assert_eq!(path.absolutize().unwrap(), Path::new("/a/c/d"));
+    ///
+    /// // With a relative path, it is first joined with the current working directory
+    /// // and then normalized
+    /// let cwd = utils::current_dir().unwrap().to_encoding::<UnixEncoding>();
+    /// let path = cwd.join(Path::new("a/b/../c/./d"));
+    /// assert_eq!(path.absolutize().unwrap(), cwd.join(Path::new("a/c/d")));
+    /// ```
+    pub fn absolutize(&self) -> io::Result<PathBuf<T>> {
+        let path = self.normalize();
+
+        if path.is_absolute() {
+            Ok(path)
+        } else {
+            // Get the cwd as a native path and convert to this path's encoding
+            let cwd = utils::current_dir()?.to_encoding();
+
+            Ok(cwd.join(path))
+        }
+    }
+
     /// Creates an owned [`PathBuf`] with `path` adjoined to `self`.
     ///
     /// See [`PathBuf::push`] for more details on what it means to adjoin a path.
@@ -770,6 +807,60 @@ where
     #[inline]
     pub fn display(&self) -> Display<T> {
         Display { path: self }
+    }
+
+    /// Converts to a different encoding, returning a new [`PathBuf`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Path, UnixEncoding, WindowsEncoding};
+    ///
+    /// // Convert from Unix to Windows
+    /// let unix_path = Path::<UnixEncoding>::new("/tmp/foo.txt");
+    /// let windows_path = unix_path.to_encoding::<WindowsEncoding>();
+    /// assert_eq!(windows_path, Path::<WindowsEncoding>::new(r"\tmp\foo.txt"));
+    ///
+    /// // Converting from Windows to Unix will drop any prefix
+    /// let windows_path = Path::<WindowsEncoding>::new(r"C:\tmp\foo.txt");
+    /// let unix_path = windows_path.to_encoding::<UnixEncoding>();
+    /// assert_eq!(unix_path, Path::<UnixEncoding>::new(r"/tmp/foo.txt"));
+    ///
+    /// // Converting to itself should retain everything
+    /// let path = Path::<WindowsEncoding>::new(r"C:\tmp\foo.txt");
+    /// assert_eq!(
+    ///     path.to_encoding::<WindowsEncoding>(),
+    ///     Path::<WindowsEncoding>::new(r"C:\tmp\foo.txt"),
+    /// );
+    /// ```
+    pub fn to_encoding<U>(&self) -> PathBuf<U>
+    where
+        U: for<'enc> Encoding<'enc>,
+    {
+        // If we're the same, just return the path buf, which
+        // we do with a fancy trick to convert it
+        if T::label() == U::label() {
+            Path::new(self.as_bytes()).to_path_buf()
+        } else {
+            // Otherwise, we have to rebuild the path from the components
+            let mut path = PathBuf::new();
+
+            // For root, current, and parent we specially handle to convert
+            // to the appropriate type, otherwise we pass along as-is
+            for component in self.components() {
+                if component.is_root() {
+                    path.push(<<<U as Encoding>::Components as Components>::Component as Component>::root().as_bytes());
+                } else if component.is_current() {
+                    path.push(<<<U as Encoding>::Components as Components>::Component as Component>::current().as_bytes());
+                } else if component.is_parent() {
+                    path.push(<<<U as Encoding>::Components as Components>::Component as Component>::parent().as_bytes());
+                } else {
+                    path.push(component.as_bytes());
+                }
+            }
+
+            path
+        }
     }
 
     /// Converts a [`Box<Path>`](Box) into a

--- a/src/common/utf8/components/component.rs
+++ b/src/common/utf8/components/component.rs
@@ -70,4 +70,13 @@ pub trait Utf8Component<'a>:
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    /// Returns a root [`Utf8Component`].
+    fn root() -> Self;
+
+    /// Returns a parent directory [`Utf8Component`].
+    fn parent() -> Self;
+
+    /// Returns a current directory [`Utf8Component`].
+    fn current() -> Self;
 }

--- a/src/common/utf8/path.rs
+++ b/src/common/utf8/path.rs
@@ -779,11 +779,20 @@ where
             // to the appropriate type, otherwise we pass along as-is
             for component in self.components() {
                 if component.is_root() {
-                    path.push(<<<U as Utf8Encoding>::Components as Utf8Components>::Component as Utf8Component>::root().as_str());
+                    path.push(<
+                        <<U as Utf8Encoding>::Components as Utf8Components>::Component 
+                        as Utf8Component
+                    >::root().as_str());
                 } else if component.is_current() {
-                    path.push(<<<U as Utf8Encoding>::Components as Utf8Components>::Component as Utf8Component>::current().as_str());
+                    path.push(<
+                        <<U as Utf8Encoding>::Components as Utf8Components>::Component 
+                        as Utf8Component
+                    >::current().as_str());
                 } else if component.is_parent() {
-                    path.push(<<<U as Utf8Encoding>::Components as Utf8Components>::Component as Utf8Component>::parent().as_str());
+                    path.push(<
+                        <<U as Utf8Encoding>::Components as Utf8Components>::Component 
+                        as Utf8Component
+                    >::parent().as_str());
                 } else {
                     path.push(component.as_str());
                 }

--- a/src/common/utf8/path.rs
+++ b/src/common/utf8/path.rs
@@ -741,6 +741,14 @@ where
 
     /// Converts to a different encoding, returning a new [`Utf8PathBuf`].
     ///
+    /// # Note
+    ///
+    /// As part of the process of converting between encodings, the path will need to be rebuilt.
+    /// This involves [`pushing`] each component, which may result in differences in the resulting
+    /// path such as resolving `.` and `..` early or other unexpected side effects.
+    ///
+    /// [`pushing`]: Utf8PathBuf::push
+    ///
     /// # Examples
     ///
     /// ```

--- a/src/common/utf8/path.rs
+++ b/src/common/utf8/path.rs
@@ -788,17 +788,17 @@ where
             for component in self.components() {
                 if component.is_root() {
                     path.push(<
-                        <<U as Utf8Encoding>::Components as Utf8Components>::Component 
+                        <<U as Utf8Encoding>::Components as Utf8Components>::Component
                         as Utf8Component
                     >::root().as_str());
                 } else if component.is_current() {
                     path.push(<
-                        <<U as Utf8Encoding>::Components as Utf8Components>::Component 
+                        <<U as Utf8Encoding>::Components as Utf8Components>::Component
                         as Utf8Component
                     >::current().as_str());
                 } else if component.is_parent() {
                     path.push(<
-                        <<U as Utf8Encoding>::Components as Utf8Components>::Component 
+                        <<U as Utf8Encoding>::Components as Utf8Components>::Component
                         as Utf8Component
                     >::parent().as_str());
                 } else {

--- a/src/common/utf8/path.rs
+++ b/src/common/utf8/path.rs
@@ -1,3 +1,4 @@
+use crate::utils;
 use crate::{
     Encoding, Path, StripPrefixError, Utf8Ancestors, Utf8Component, Utf8Components, Utf8Encoding,
     Utf8Iter, Utf8PathBuf,
@@ -6,6 +7,7 @@ use std::{
     borrow::{Cow, ToOwned},
     cmp, fmt,
     hash::{Hash, Hasher},
+    io,
     marker::PhantomData,
     rc::Rc,
     str::Utf8Error,
@@ -558,6 +560,42 @@ where
         path
     }
 
+    /// Converts a path to an absolute form by [`normalizing`] the path, returning a
+    /// [`Utf8PathBuf`].
+    ///
+    /// In the case that the path is relative, the current working directory is prepended prior to
+    /// normalizing.
+    ///
+    /// [`normalizing`]: Utf8Path::normalize
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{utils, Utf8Path, Utf8UnixEncoding};
+    ///
+    /// // With an absolute path, it is just normalized
+    /// let path = Utf8Path::<Utf8UnixEncoding>::new("/a/b/../c/./d");
+    /// assert_eq!(path.absolutize().unwrap(), Utf8Path::new("/a/c/d"));
+    ///
+    /// // With a relative path, it is first joined with the current working directory
+    /// // and then normalized
+    /// let cwd = utils::utf8_current_dir().unwrap().to_encoding::<Utf8UnixEncoding>();
+    /// let path = cwd.join(Utf8Path::new("a/b/../c/./d"));
+    /// assert_eq!(path.absolutize().unwrap(), cwd.join(Utf8Path::new("a/c/d")));
+    /// ```
+    pub fn absolutize(&self) -> io::Result<Utf8PathBuf<T>> {
+        let path = self.normalize();
+
+        if path.is_absolute() {
+            Ok(path)
+        } else {
+            // Get the cwd as a native path and convert to this path's encoding
+            let cwd = utils::utf8_current_dir()?.to_encoding();
+
+            Ok(cwd.join(path))
+        }
+    }
+
     /// Creates an owned [`Utf8PathBuf`] with `path` adjoined to `self`.
     ///
     /// See [`Utf8PathBuf::push`] for more details on what it means to adjoin a path.
@@ -699,6 +737,60 @@ where
     #[inline]
     pub fn iter(&self) -> Utf8Iter<T> {
         Utf8Iter::new(self.components())
+    }
+
+    /// Converts to a different encoding, returning a new [`Utf8PathBuf`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Utf8Path, Utf8UnixEncoding, Utf8WindowsEncoding};
+    ///
+    /// // Convert from Unix to Windows
+    /// let unix_path = Utf8Path::<Utf8UnixEncoding>::new("/tmp/foo.txt");
+    /// let windows_path = unix_path.to_encoding::<Utf8WindowsEncoding>();
+    /// assert_eq!(windows_path, Utf8Path::<Utf8WindowsEncoding>::new(r"\tmp\foo.txt"));
+    ///
+    /// // Converting from Windows to Unix will drop any prefix
+    /// let windows_path = Utf8Path::<Utf8WindowsEncoding>::new(r"C:\tmp\foo.txt");
+    /// let unix_path = windows_path.to_encoding::<Utf8UnixEncoding>();
+    /// assert_eq!(unix_path, Utf8Path::<Utf8UnixEncoding>::new(r"/tmp/foo.txt"));
+    ///
+    /// // Converting to itself should retain everything
+    /// let path = Utf8Path::<Utf8WindowsEncoding>::new(r"C:\tmp\foo.txt");
+    /// assert_eq!(
+    ///     path.to_encoding::<Utf8WindowsEncoding>(),
+    ///     Utf8Path::<Utf8WindowsEncoding>::new(r"C:\tmp\foo.txt"),
+    /// );
+    /// ```
+    pub fn to_encoding<U>(&self) -> Utf8PathBuf<U>
+    where
+        U: for<'enc> Utf8Encoding<'enc>,
+    {
+        // If we're the same, just return the path buf, which
+        // we do with a fancy trick to convert it
+        if T::label() == U::label() {
+            Utf8Path::new(self.as_str()).to_path_buf()
+        } else {
+            // Otherwise, we have to rebuild the path from the components
+            let mut path = Utf8PathBuf::new();
+
+            // For root, current, and parent we specially handle to convert
+            // to the appropriate type, otherwise we pass along as-is
+            for component in self.components() {
+                if component.is_root() {
+                    path.push(<<<U as Utf8Encoding>::Components as Utf8Components>::Component as Utf8Component>::root().as_str());
+                } else if component.is_current() {
+                    path.push(<<<U as Utf8Encoding>::Components as Utf8Components>::Component as Utf8Component>::current().as_str());
+                } else if component.is_parent() {
+                    path.push(<<<U as Utf8Encoding>::Components as Utf8Components>::Component as Utf8Component>::parent().as_str());
+                } else {
+                    path.push(component.as_str());
+                }
+            }
+
+            path
+        }
     }
 
     /// Converts a [`Box<Utf8Path>`](Box) into a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod common;
 mod convert;
 pub mod native;
 pub mod unix;
+pub mod utils;
 pub mod windows;
 
 mod private {

--- a/src/native.rs
+++ b/src/native.rs
@@ -2,6 +2,10 @@ pub use self::non_utf8::*;
 pub use self::utf8::*;
 
 mod non_utf8 {
+    /// [`Encoding`](crate::Encoding) that is native to the platform during compilation
+    #[cfg(unix)]
+    pub type NativeEncoding = crate::unix::UnixEncoding;
+
     /// [`Path`](crate::Path) that is native to the platform during compilation
     #[cfg(unix)]
     pub type NativePath = crate::unix::UnixPath;
@@ -13,6 +17,10 @@ mod non_utf8 {
     /// [`Component`](crate::Component) that is native to the platform during compilation
     #[cfg(unix)]
     pub type NativeComponent<'a> = crate::unix::UnixComponent<'a>;
+
+    /// [`Encoding`](crate::Encoding) that is native to the platform during compilation
+    #[cfg(windows)]
+    pub type NativeEncoding = crate::windows::WindowsEncoding;
 
     /// [`Path`](crate::Path) that is native to the platform during compilation
     #[cfg(windows)]
@@ -39,6 +47,10 @@ mod non_utf8 {
 }
 
 mod utf8 {
+    /// [`Utf8Path`](crate::Utf8Encoding) that is native to the platform during compilation
+    #[cfg(unix)]
+    pub type Utf8NativeEncoding = crate::unix::Utf8UnixEncoding;
+
     /// [`Utf8Path`](crate::Utf8Path) that is native to the platform during compilation
     #[cfg(unix)]
     pub type Utf8NativePath = crate::unix::Utf8UnixPath;
@@ -50,6 +62,10 @@ mod utf8 {
     /// [`Utf8Component`](crate::Utf8Component) that is native to the platform during compilation
     #[cfg(unix)]
     pub type Utf8NativeComponent<'a> = crate::unix::Utf8UnixComponent<'a>;
+
+    /// [`Utf8Path`](crate::Utf8Encoding) that is native to the platform during compilation
+    #[cfg(windows)]
+    pub type Utf8NativeEncoding = crate::windows::Utf8WindowsEncoding;
 
     /// [`Utf8Path`](crate::Utf8Path) that is native to the platform during compilation
     #[cfg(windows)]

--- a/src/unix/non_utf8/components/component.rs
+++ b/src/unix/non_utf8/components/component.rs
@@ -127,6 +127,45 @@ impl<'a> Component<'a> for UnixComponent<'a> {
     fn len(&self) -> usize {
         self.as_bytes().len()
     }
+
+    /// Returns the root directory component.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Component, unix::UnixComponent};
+    ///
+    /// assert_eq!(UnixComponent::root(), UnixComponent::RootDir);
+    /// ```
+    fn root() -> Self {
+        Self::RootDir
+    }
+
+    /// Returns the parent directory component.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Component, unix::UnixComponent};
+    ///
+    /// assert_eq!(UnixComponent::parent(), UnixComponent::ParentDir);
+    /// ```
+    fn parent() -> Self {
+        Self::ParentDir
+    }
+
+    /// Returns the current directory component.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Component, unix::UnixComponent};
+    ///
+    /// assert_eq!(UnixComponent::current(), UnixComponent::CurDir);
+    /// ```
+    fn current() -> Self {
+        Self::CurDir
+    }
 }
 
 impl AsRef<[u8]> for UnixComponent<'_> {

--- a/src/unix/utf8/components/component.rs
+++ b/src/unix/utf8/components/component.rs
@@ -206,6 +206,45 @@ impl<'a> Utf8Component<'a> for Utf8UnixComponent<'a> {
     fn len(&self) -> usize {
         self.as_str().len()
     }
+
+    /// Returns the root directory component.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Utf8Component, unix::Utf8UnixComponent};
+    ///
+    /// assert_eq!(Utf8UnixComponent::root(), Utf8UnixComponent::RootDir);
+    /// ```
+    fn root() -> Self {
+        Self::RootDir
+    }
+
+    /// Returns the parent directory component.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Utf8Component, unix::Utf8UnixComponent};
+    ///
+    /// assert_eq!(Utf8UnixComponent::parent(), Utf8UnixComponent::ParentDir);
+    /// ```
+    fn parent() -> Self {
+        Self::ParentDir
+    }
+
+    /// Returns the current directory component.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Utf8Component, unix::Utf8UnixComponent};
+    ///
+    /// assert_eq!(Utf8UnixComponent::current(), Utf8UnixComponent::CurDir);
+    /// ```
+    fn current() -> Self {
+        Self::CurDir
+    }
 }
 
 impl AsRef<[u8]> for Utf8UnixComponent<'_> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,64 @@
+use crate::{NativePathBuf, Utf8NativePathBuf};
+
+use std::convert::TryFrom;
+use std::{env, io};
+
+/// Returns the current working directory as [`NativePathBuf`].
+///
+/// # Errors
+///
+/// Returns an [`Err`] if the current working directory value is invalid
+/// or unable to parse the directory with the native encoding.
+///
+/// Possible cases:
+///
+/// * Current directory does not exist.
+/// * There are insufficient permissions to access the current directory.
+/// * The encoding used to parse the current directory failed to parse.
+///
+/// # Examples
+///
+/// ```
+/// fn main() -> std::io::Result<()> {
+///     let path = typed_path::utils::current_dir()?;
+///     println!("The current directory is {}", path.display());
+///     Ok(())
+/// }
+/// ```
+pub fn current_dir() -> io::Result<NativePathBuf> {
+    let std_path = env::current_dir()?;
+    match NativePathBuf::try_from(std_path) {
+        Ok(path) => Ok(path),
+        _ => Err(io::Error::new(io::ErrorKind::InvalidData, "wrong encoding")),
+    }
+}
+
+/// Returns the current working directory as [`Utf8NativePathBuf`].
+///
+/// # Errors
+///
+/// Returns an [`Err`] if the current working directory value is invalid
+/// or unable to parse the directory with the native encoding.
+///
+/// Possible cases:
+///
+/// * Current directory does not exist.
+/// * There are insufficient permissions to access the current directory.
+/// * The encoding used to parse the current directory failed to parse.
+/// * The current directory was not valid UTF8.
+///
+/// # Examples
+///
+/// ```
+/// fn main() -> std::io::Result<()> {
+///     let path = typed_path::utils::utf8_current_dir()?;
+///     println!("The current directory is {}", path);
+///     Ok(())
+/// }
+/// ```
+pub fn utf8_current_dir() -> io::Result<Utf8NativePathBuf> {
+    match Utf8NativePathBuf::from_bytes_path_buf(current_dir()?) {
+        Ok(path) => Ok(path),
+        Err(x) => Err(io::Error::new(io::ErrorKind::InvalidData, x)),
+    }
+}

--- a/src/windows/non_utf8/components/component.rs
+++ b/src/windows/non_utf8/components/component.rs
@@ -173,6 +173,45 @@ impl<'a> Component<'a> for WindowsComponent<'a> {
     fn len(&self) -> usize {
         self.as_bytes().len()
     }
+
+    /// Returns the root directory component.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Component, windows::WindowsComponent};
+    ///
+    /// assert_eq!(WindowsComponent::root(), WindowsComponent::RootDir);
+    /// ```
+    fn root() -> Self {
+        Self::RootDir
+    }
+
+    /// Returns the parent directory component.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Component, windows::WindowsComponent};
+    ///
+    /// assert_eq!(WindowsComponent::parent(), WindowsComponent::ParentDir);
+    /// ```
+    fn parent() -> Self {
+        Self::ParentDir
+    }
+
+    /// Returns the current directory component.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Component, windows::WindowsComponent};
+    ///
+    /// assert_eq!(WindowsComponent::current(), WindowsComponent::CurDir);
+    /// ```
+    fn current() -> Self {
+        Self::CurDir
+    }
 }
 
 impl AsRef<[u8]> for WindowsComponent<'_> {

--- a/src/windows/utf8/components/component.rs
+++ b/src/windows/utf8/components/component.rs
@@ -254,6 +254,45 @@ impl<'a> Utf8Component<'a> for Utf8WindowsComponent<'a> {
     fn len(&self) -> usize {
         self.as_str().len()
     }
+
+    /// Returns the root directory component.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Utf8Component, windows::Utf8WindowsComponent};
+    ///
+    /// assert_eq!(Utf8WindowsComponent::root(), Utf8WindowsComponent::RootDir);
+    /// ```
+    fn root() -> Self {
+        Self::RootDir
+    }
+
+    /// Returns the parent directory component.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Utf8Component, windows::Utf8WindowsComponent};
+    ///
+    /// assert_eq!(Utf8WindowsComponent::parent(), Utf8WindowsComponent::ParentDir);
+    /// ```
+    fn parent() -> Self {
+        Self::ParentDir
+    }
+
+    /// Returns the current directory component.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Utf8Component, windows::Utf8WindowsComponent};
+    ///
+    /// assert_eq!(Utf8WindowsComponent::current(), Utf8WindowsComponent::CurDir);
+    /// ```
+    fn current() -> Self {
+        Self::CurDir
+    }
 }
 
 impl AsRef<[u8]> for Utf8WindowsComponent<'_> {


### PR DESCRIPTION
Adds `absolutize` and `to_encoding` to the `Path` and `Utf8Path` structs while also adding `root`, `parent`, and `current` static methods to the `Component` and `Utf8Component` traits.

This should ideally provide similar functionality to [path-absolutize](https://github.com/magiclen/path-absolutize).

Finishes resolving #8.