### PR TITLE
Add no_std support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,13 @@ on:
 
 jobs:
   clippy:
-    name: "Lint with clippy (${{ matrix.os }})"
+    name: "Lint with clippy (${{ matrix.os }}, ${{ matrix.flags }})"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - { os: windows-latest }
-          - { os: ubuntu-latest }
+        os: ["windows-latest", "ubuntu-latest"]
+        flags: ["--all-features", "--no-default-features"]
     env:
       RUSTFLAGS: -Dwarnings
     steps:
@@ -33,7 +32,7 @@ jobs:
           profile: minimal
           toolchain: stable
           components: clippy
-      - run: cargo clippy --all-targets --all-features
+      - run: cargo clippy --all-targets ${{ matrix.flags }}
   rustfmt:
     name: "Verify code formatting (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
@@ -58,16 +57,20 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
   tests:
-    name: "Test Rust ${{ matrix.rust }} (${{ matrix.os }})"
+    name: "Test Rust ${{ matrix.rust }} (${{ matrix.os }}, ${{ matrix.flags }})"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { rust: stable, os: windows-latest, target: x86_64-pc-windows-msvc }
-          - { rust: stable, os: macos-latest }
-          - { rust: stable, os: ubuntu-latest }
-          - { rust: 1.58.1, os: ubuntu-latest }
+          - { rust: stable, os: windows-latest, target: x86_64-pc-windows-msvc, flags: "--all-features" }
+          - { rust: stable, os: windows-latest, target: x86_64-pc-windows-msvc, flags: "--no-default-features" }
+          - { rust: stable, os: macos-latest, flags: "--all-features" }
+          - { rust: stable, os: macos-latest, flags: "--no-default-features" }
+          - { rust: stable, os: ubuntu-latest, flags: "--all-features" }
+          - { rust: stable, os: ubuntu-latest, flags: "--no-default-features" }
+          - { rust: 1.58.1, os: ubuntu-latest, flags: "--all-features" }
+          - { rust: 1.58.1, os: ubuntu-latest, flags: "--no-default-features" }
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust ${{ matrix.rust }} ${{ matrix.target }}
@@ -76,7 +79,7 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
-      - run: cargo test --all-features
+      - run: cargo test ${{ matrix.flags }}
   examples:
     name: "Run examples using Rust ${{ matrix.rust }} (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Support `no_std` environments, when `default-features = false` is set for the crate
+
 ## [0.6.0] - 2023-10-12
 
 * Refactor crate exports such that everything other than constants are now

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,32 @@ repository = "https://github.com/chipsenkbeil/typed-path"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 
+[[example]]
+name = "windows_utf8"
+required-features = ["std"]
+
+[[example]]
+name = "unix"
+required-features = ["std"]
+
+[[example]]
+name = "typed"
+required-features = ["std"]
+
+[[example]]
+name = "typed_utf8"
+required-features = ["std"]
+
+[[example]]
+name = "unix_utf8"
+required-features = ["std"]
+
+[[example]]
+name = "windows"
+required-features = ["std"]
+
 [dependencies]
+
+[features]
+default = ["std"]
+std = []

--- a/README.md
+++ b/README.md
@@ -188,9 +188,13 @@ assert_eq!(
 
 In addition, you can leverage `absolutize` to convert a path to an absolute
 form by prepending the current working directory if the path is relative and
-then normalizing it:
+then normalizing it (requires `std` feature):
 
 ```rust
+# fn main() {
+# // absolutize is only supported with standard library
+# #[cfg(feature = "std")]
+# {
 use typed_path::{utils, Utf8UnixPath};
 
 // With an absolute path, it is just normalized
@@ -202,15 +206,21 @@ assert_eq!(path.absolutize().unwrap(), Utf8UnixPath::new("/a/c/d"));
 let cwd = utils::utf8_current_dir().unwrap().with_unix_encoding();
 let path = cwd.join(Utf8UnixPath::new("a/b/../c/./d"));
 assert_eq!(path.absolutize().unwrap(), cwd.join(Utf8UnixPath::new("a/c/d")));
+# }
+# }
 ```
 
 ### Current directory
 
-Helper functions are available in the [`utils`][utils] module, and one of those
-provides an identical experience to
+Helper functions are available in the [`utils`][utils] module (requires `std`
+feature), and one of those provides an identical experience to
 [`std::env::current_dir`](https://doc.rust-lang.org/std/env/fn.current_dir.html):
 
 ```rust
+# fn main() {
+# // utils::current_dir is only supported with standard library
+# #[cfg(feature = "std")]
+# {
 // Retrieves the current directory as a NativePath:
 //
 // * For Unix family, this would be Path<UnixEncoding>
@@ -222,6 +232,8 @@ let _cwd = typed_path::utils::current_dir().unwrap();
 // * For Unix family, this would be Utf8Path<Utf8UnixEncoding>
 // * For Windows family, this would be Utf8Path<Utf8WindowsEncoding>
 let _utf8_cwd = typed_path::utils::utf8_current_dir().unwrap();
+# }
+# }
 ```
 
 ## License

--- a/src/common/errors.rs
+++ b/src/common/errors.rs
@@ -1,5 +1,4 @@
-use std::error::Error;
-use std::fmt;
+use core::fmt;
 
 /// An error returned if the prefix was not found.
 ///
@@ -17,4 +16,5 @@ impl fmt::Display for StripPrefixError {
     }
 }
 
-impl Error for StripPrefixError {}
+#[cfg(feature = "std")]
+impl std::error::Error for StripPrefixError {}

--- a/src/common/non_utf8.rs
+++ b/src/common/non_utf8.rs
@@ -6,7 +6,7 @@ mod pathbuf;
 #[macro_use]
 pub(crate) mod parser;
 
-use std::hash::Hasher;
+use core::hash::Hasher;
 
 pub use components::*;
 pub use iter::*;
@@ -14,6 +14,7 @@ pub use parser::ParseError;
 pub use path::*;
 pub use pathbuf::*;
 
+use crate::no_std_compat::*;
 use crate::private;
 
 /// Interface to provide meaning to a byte slice such that paths can be derived

--- a/src/common/non_utf8/components.rs
+++ b/src/common/non_utf8/components.rs
@@ -1,6 +1,6 @@
 mod component;
 
-use std::{cmp, fmt, iter};
+use core::{cmp, fmt, iter};
 
 pub use component::*;
 

--- a/src/common/non_utf8/components/component.rs
+++ b/src/common/non_utf8/components/component.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 use crate::private;
 

--- a/src/common/non_utf8/iter.rs
+++ b/src/common/non_utf8/iter.rs
@@ -1,6 +1,6 @@
-use std::fmt;
-use std::iter::FusedIterator;
-use std::marker::PhantomData;
+use core::fmt;
+use core::iter::FusedIterator;
+use core::marker::PhantomData;
 
 use crate::{Component, Components, Encoding, Path};
 

--- a/src/common/non_utf8/parser.rs
+++ b/src/common/non_utf8/parser.rs
@@ -1,3 +1,5 @@
+use crate::no_std_compat::*;
+
 pub type ParseResult<'a, T> = Result<(ParseInput<'a>, T), ParseError>;
 pub type ParseInput<'a> = &'a [u8];
 pub type ParseError = &'static str;

--- a/src/common/non_utf8/path.rs
+++ b/src/common/non_utf8/path.rs
@@ -1,15 +1,16 @@
 mod display;
 
-use std::borrow::{Cow, ToOwned};
-use std::hash::{Hash, Hasher};
-use std::marker::PhantomData;
-use std::rc::Rc;
-use std::sync::Arc;
-use std::{cmp, fmt, io};
+use alloc::borrow::{Cow, ToOwned};
+use alloc::rc::Rc;
+use alloc::sync::Arc;
+use core::hash::{Hash, Hasher};
+use core::marker::PhantomData;
+use core::{cmp, fmt};
 
 pub use display::Display;
 
-use crate::{utils, Ancestors, Component, Components, Encoding, Iter, PathBuf, StripPrefixError};
+use crate::no_std_compat::*;
+use crate::{Ancestors, Component, Components, Encoding, Iter, PathBuf, StripPrefixError};
 
 /// A slice of a path (akin to [`str`]).
 ///
@@ -159,7 +160,7 @@ where
     /// ```
     #[inline]
     pub fn to_str(&self) -> Option<&str> {
-        std::str::from_utf8(&self.inner).ok()
+        core::str::from_utf8(&self.inner).ok()
     }
 
     /// Converts a `Path` to a [`Cow<str>`].
@@ -628,12 +629,13 @@ where
     /// let path = cwd.join(Path::new("a/b/../c/./d"));
     /// assert_eq!(path.absolutize().unwrap(), cwd.join(Path::new("a/c/d")));
     /// ```
-    pub fn absolutize(&self) -> io::Result<PathBuf<T>> {
+    #[cfg(feature = "std")]
+    pub fn absolutize(&self) -> std::io::Result<PathBuf<T>> {
         if self.is_absolute() {
             Ok(self.normalize())
         } else {
             // Get the cwd as a native path and convert to this path's encoding
-            let cwd = utils::current_dir()?.with_encoding();
+            let cwd = crate::utils::current_dir()?.with_encoding();
 
             Ok(cwd.join(self).normalize())
         }

--- a/src/common/non_utf8/path/display.rs
+++ b/src/common/non_utf8/path/display.rs
@@ -1,5 +1,6 @@
-use std::fmt;
+use core::fmt;
 
+use crate::no_std_compat::*;
 use crate::{Encoding, Path};
 
 /// Helper struct for safely printing paths with [`format!`] and `{}`.

--- a/src/common/non_utf8/pathbuf.rs
+++ b/src/common/non_utf8/pathbuf.rs
@@ -1,12 +1,14 @@
-use std::borrow::{Borrow, Cow};
-use std::collections::TryReserveError;
-use std::hash::{Hash, Hasher};
-use std::iter::{Extend, FromIterator};
-use std::marker::PhantomData;
-use std::ops::Deref;
-use std::str::FromStr;
-use std::{cmp, fmt};
+use alloc::borrow::Cow;
+use alloc::collections::TryReserveError;
+use core::borrow::Borrow;
+use core::hash::{Hash, Hasher};
+use core::iter::{Extend, FromIterator};
+use core::marker::PhantomData;
+use core::ops::Deref;
+use core::str::FromStr;
+use core::{cmp, fmt};
 
+use crate::no_std_compat::*;
 use crate::{Encoding, Iter, Path};
 
 /// An owned, mutable path that mirrors [`std::path::PathBuf`], but operatings using an

--- a/src/common/utf8.rs
+++ b/src/common/utf8.rs
@@ -3,13 +3,14 @@ mod iter;
 mod path;
 mod pathbuf;
 
-use std::hash::Hasher;
+use core::hash::Hasher;
 
 pub use components::*;
 pub use iter::*;
 pub use path::*;
 pub use pathbuf::*;
 
+use crate::no_std_compat::*;
 use crate::private;
 
 /// Interface to provide meaning to a byte slice such that paths can be derived

--- a/src/common/utf8/components.rs
+++ b/src/common/utf8/components.rs
@@ -1,6 +1,6 @@
 mod component;
 
-use std::{cmp, fmt, iter};
+use core::{cmp, fmt, iter};
 
 pub use component::*;
 

--- a/src/common/utf8/components/component.rs
+++ b/src/common/utf8/components/component.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 use crate::private;
 

--- a/src/common/utf8/iter.rs
+++ b/src/common/utf8/iter.rs
@@ -1,6 +1,6 @@
-use std::fmt;
-use std::iter::FusedIterator;
-use std::marker::PhantomData;
+use core::fmt;
+use core::iter::FusedIterator;
+use core::marker::PhantomData;
 
 use crate::{Utf8Component, Utf8Components, Utf8Encoding, Utf8Path};
 

--- a/src/common/utf8/path.rs
+++ b/src/common/utf8/path.rs
@@ -1,14 +1,15 @@
-use std::borrow::{Cow, ToOwned};
-use std::hash::{Hash, Hasher};
-use std::marker::PhantomData;
-use std::rc::Rc;
-use std::str::Utf8Error;
-use std::sync::Arc;
-use std::{cmp, fmt, io};
+use alloc::borrow::{Cow, ToOwned};
+use alloc::rc::Rc;
+use alloc::sync::Arc;
+use core::hash::{Hash, Hasher};
+use core::marker::PhantomData;
+use core::str::Utf8Error;
+use core::{cmp, fmt};
 
+use crate::no_std_compat::*;
 use crate::{
-    utils, Encoding, Path, StripPrefixError, Utf8Ancestors, Utf8Component, Utf8Components,
-    Utf8Encoding, Utf8Iter, Utf8PathBuf,
+    Encoding, Path, StripPrefixError, Utf8Ancestors, Utf8Component, Utf8Components, Utf8Encoding,
+    Utf8Iter, Utf8PathBuf,
 };
 
 /// A slice of a path (akin to [`str`]).
@@ -580,12 +581,13 @@ where
     /// let path = cwd.join(Utf8Path::new("a/b/../c/./d"));
     /// assert_eq!(path.absolutize().unwrap(), cwd.join(Utf8Path::new("a/c/d")));
     /// ```
-    pub fn absolutize(&self) -> io::Result<Utf8PathBuf<T>> {
+    #[cfg(feature = "std")]
+    pub fn absolutize(&self) -> std::io::Result<Utf8PathBuf<T>> {
         if self.is_absolute() {
             Ok(self.normalize())
         } else {
             // Get the cwd as a native path and convert to this path's encoding
-            let cwd = utils::utf8_current_dir()?.with_encoding();
+            let cwd = crate::utils::utf8_current_dir()?.with_encoding();
 
             Ok(cwd.join(self).normalize())
         }
@@ -837,7 +839,7 @@ where
     where
         U: for<'enc> Encoding<'enc>,
     {
-        Ok(Self::new(std::str::from_utf8(path.as_bytes())?))
+        Ok(Self::new(core::str::from_utf8(path.as_bytes())?))
     }
 
     /// Converts a non-UTF-8 [`Path`] to a UTF-8 [`Utf8Path`] without checking that the path
@@ -866,7 +868,7 @@ where
     where
         U: for<'enc> Encoding<'enc>,
     {
-        Self::new(std::str::from_utf8_unchecked(path.as_bytes()))
+        Self::new(core::str::from_utf8_unchecked(path.as_bytes()))
     }
 
     /// Converts a UTF-8 [`Utf8Path`] to a non-UTF-8 [`Path`].

--- a/src/common/utf8/pathbuf.rs
+++ b/src/common/utf8/pathbuf.rs
@@ -1,13 +1,15 @@
-use std::borrow::{Borrow, Cow};
-use std::collections::TryReserveError;
-use std::hash::{Hash, Hasher};
-use std::iter::{Extend, FromIterator};
-use std::marker::PhantomData;
-use std::ops::Deref;
-use std::str::FromStr;
-use std::string::FromUtf8Error;
-use std::{cmp, fmt};
+use alloc::borrow::Cow;
+use alloc::collections::TryReserveError;
+use alloc::string::FromUtf8Error;
+use core::borrow::Borrow;
+use core::hash::{Hash, Hasher};
+use core::iter::{Extend, FromIterator};
+use core::marker::PhantomData;
+use core::ops::Deref;
+use core::str::FromStr;
+use core::{cmp, fmt};
 
+use crate::no_std_compat::*;
 use crate::{Encoding, PathBuf, Utf8Encoding, Utf8Iter, Utf8Path};
 
 /// An owned, mutable path that mirrors [`std::path::PathBuf`], but operatings using a

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,17 +1,24 @@
-use std::convert::TryFrom;
-use std::ffi::OsStr;
-use std::path::{Component as StdComponent, Path as StdPath, PathBuf as StdPathBuf};
+#[cfg(feature = "std")]
+use std::{
+    convert::TryFrom,
+    ffi::OsStr,
+    path::{Component as StdComponent, Path as StdPath, PathBuf as StdPathBuf},
+};
 
-use crate::native::{Utf8NativePath, Utf8NativePathBuf};
-use crate::unix::UnixComponent;
-use crate::windows::{WindowsComponent, WindowsPrefixComponent};
-use crate::{Encoding, Path, PathBuf};
+#[cfg(feature = "std")]
+use crate::{
+    native::{Utf8NativePath, Utf8NativePathBuf},
+    unix::UnixComponent,
+    windows::{WindowsComponent, WindowsPrefixComponent},
+    Encoding, Path, PathBuf,
+};
 
 /// Interface to try to perform a cheap reference-to-reference conversion.
 pub trait TryAsRef<T: ?Sized> {
     fn try_as_ref(&self) -> Option<&T>;
 }
 
+#[cfg(feature = "std")]
 impl<T> TryAsRef<StdPath> for Path<T>
 where
     T: for<'enc> Encoding<'enc>,
@@ -33,6 +40,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T> TryAsRef<Path<T>> for StdPath
 where
     T: for<'enc> Encoding<'enc>,
@@ -54,6 +62,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T> TryFrom<PathBuf<T>> for StdPathBuf
 where
     T: for<'enc> Encoding<'enc>,
@@ -81,6 +90,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T> TryFrom<StdPathBuf> for PathBuf<T>
 where
     T: for<'enc> Encoding<'enc>,
@@ -108,6 +118,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> TryFrom<UnixComponent<'a>> for StdComponent<'a> {
     type Error = UnixComponent<'a>;
 
@@ -146,6 +157,7 @@ impl<'a> TryFrom<UnixComponent<'a>> for StdComponent<'a> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> TryFrom<StdComponent<'a>> for UnixComponent<'a> {
     type Error = StdComponent<'a>;
 
@@ -183,6 +195,7 @@ impl<'a> TryFrom<StdComponent<'a>> for UnixComponent<'a> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> TryFrom<WindowsComponent<'a>> for StdComponent<'a> {
     type Error = WindowsComponent<'a>;
 
@@ -245,6 +258,7 @@ impl<'a> TryFrom<WindowsComponent<'a>> for StdComponent<'a> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> TryFrom<StdComponent<'a>> for WindowsComponent<'a> {
     type Error = StdComponent<'a>;
 
@@ -292,6 +306,7 @@ impl<'a> TryFrom<StdComponent<'a>> for WindowsComponent<'a> {
     }
 }
 
+#[cfg(feature = "std")]
 impl AsRef<StdPath> for Utf8NativePath {
     /// Converts a native utf8 path (based on compilation family) into [`std::path::Path`].
     ///
@@ -309,6 +324,7 @@ impl AsRef<StdPath> for Utf8NativePath {
     }
 }
 
+#[cfg(feature = "std")]
 impl AsRef<StdPath> for Utf8NativePathBuf {
     /// Converts a native utf8 pathbuf (based on compilation family) into [`std::path::Path`].
     ///
@@ -326,6 +342,7 @@ impl AsRef<StdPath> for Utf8NativePathBuf {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> From<&'a Utf8NativePath> for StdPathBuf {
     /// Converts a native utf8 path (based on compilation family) into [`std::path::PathBuf`].
     ///
@@ -343,6 +360,7 @@ impl<'a> From<&'a Utf8NativePath> for StdPathBuf {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<Utf8NativePathBuf> for StdPathBuf {
     /// Converts a native utf8 pathbuf (based on compilation family) into [`std::path::PathBuf`].
     ///
@@ -367,6 +385,7 @@ impl From<Utf8NativePathBuf> for StdPathBuf {
     target_os = "hermit",
     target_os = "wasi"
 ))]
+#[cfg(feature = "std")]
 mod common {
     use std::ffi::{OsStr, OsString};
     #[cfg(all(target_vendor = "fortanix", target_env = "sgx"))]
@@ -434,6 +453,7 @@ mod common {
 }
 
 #[cfg(test)]
+#[cfg(feature = "std")]
 mod tests {
     use std::convert::TryFrom;
     use std::path::Component;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,20 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #[doc = include_str!("../README.md")]
-#[cfg(doctest)]
+#[cfg(all(doctest, feature = "std"))]
 pub struct ReadmeDoctests;
+
+extern crate alloc;
+
+mod no_std_compat {
+    pub use alloc::{
+        boxed::Box,
+        string::{String, ToString},
+        vec,
+        vec::Vec,
+    };
+}
 
 #[macro_use]
 mod common;
@@ -10,6 +22,7 @@ mod convert;
 mod native;
 mod typed;
 mod unix;
+#[cfg(feature = "std")]
 pub mod utils;
 mod windows;
 

--- a/src/typed/non_utf8/components.rs
+++ b/src/typed/non_utf8/components.rs
@@ -1,7 +1,7 @@
 mod component;
 pub use component::*;
 
-use std::{cmp, fmt, iter};
+use core::{cmp, fmt, iter};
 
 use crate::typed::TypedPath;
 use crate::unix::UnixComponents;

--- a/src/typed/non_utf8/iter.rs
+++ b/src/typed/non_utf8/iter.rs
@@ -1,5 +1,5 @@
-use std::fmt;
-use std::iter::FusedIterator;
+use core::fmt;
+use core::iter::FusedIterator;
 
 use crate::common::{Ancestors, Iter};
 use crate::typed::TypedPath;

--- a/src/typed/non_utf8/path.rs
+++ b/src/typed/non_utf8/path.rs
@@ -1,6 +1,8 @@
-use std::borrow::Cow;
-use std::path::Path;
-use std::{fmt, io};
+use alloc::borrow::Cow;
+use core::fmt;
+
+#[cfg(feature = "std")]
+use std::{io, path::Path};
 
 use crate::common::StripPrefixError;
 use crate::convert::TryAsRef;
@@ -532,6 +534,7 @@ impl<'a> TypedPath<'a> {
     /// let path = cwd.join("a/b/../c/./d");
     /// assert_eq!(path.absolutize().unwrap(), cwd.join("a/c/d"));
     /// ```
+    #[cfg(feature = "std")]
     pub fn absolutize(&self) -> io::Result<TypedPathBuf> {
         Ok(match self {
             Self::Unix(path) => TypedPathBuf::Unix(path.absolutize()?),
@@ -783,6 +786,7 @@ impl TryAsRef<WindowsPath> for TypedPath<'_> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> TryAsRef<Path> for TypedPath<'a> {
     fn try_as_ref(&self) -> Option<&Path> {
         match self {

--- a/src/typed/non_utf8/pathbuf.rs
+++ b/src/typed/non_utf8/pathbuf.rs
@@ -1,10 +1,12 @@
-use std::borrow::Cow;
-use std::collections::TryReserveError;
-use std::convert::TryFrom;
-use std::io;
-use std::path::PathBuf;
+use alloc::borrow::Cow;
+use alloc::collections::TryReserveError;
+use core::convert::TryFrom;
+
+#[cfg(feature = "std")]
+use std::{io, path::PathBuf};
 
 use crate::common::StripPrefixError;
+use crate::no_std_compat::*;
 use crate::typed::{PathType, TypedAncestors, TypedComponents, TypedIter, TypedPath};
 use crate::unix::{UnixPath, UnixPathBuf};
 use crate::windows::{WindowsPath, WindowsPathBuf};
@@ -748,6 +750,7 @@ impl TypedPathBuf {
     /// let path = cwd.join("a/b/../c/./d");
     /// assert_eq!(path.absolutize().unwrap(), cwd.join("a/c/d"));
     /// ```
+    #[cfg(feature = "std")]
     pub fn absolutize(&self) -> io::Result<TypedPathBuf> {
         self.to_path().absolutize()
     }
@@ -974,6 +977,7 @@ impl TryFrom<TypedPathBuf> for WindowsPathBuf {
     }
 }
 
+#[cfg(feature = "std")]
 impl TryFrom<TypedPathBuf> for PathBuf {
     type Error = TypedPathBuf;
 

--- a/src/typed/utf8/components.rs
+++ b/src/typed/utf8/components.rs
@@ -1,7 +1,7 @@
 mod component;
 pub use component::*;
 
-use std::{cmp, fmt, iter};
+use core::{cmp, fmt, iter};
 
 use crate::typed::Utf8TypedPath;
 use crate::unix::Utf8UnixComponents;

--- a/src/typed/utf8/components/component.rs
+++ b/src/typed/utf8/components/component.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 use crate::typed::Utf8TypedPath;
 use crate::unix::Utf8UnixComponent;

--- a/src/typed/utf8/iter.rs
+++ b/src/typed/utf8/iter.rs
@@ -1,5 +1,5 @@
-use std::fmt;
-use std::iter::FusedIterator;
+use core::fmt;
+use core::iter::FusedIterator;
 
 use crate::common::{Utf8Ancestors, Utf8Iter};
 use crate::typed::Utf8TypedPath;

--- a/src/typed/utf8/path.rs
+++ b/src/typed/utf8/path.rs
@@ -1,5 +1,7 @@
+use core::fmt;
+
+#[cfg(feature = "std")]
 use std::path::Path;
-use std::{fmt, io};
 
 use crate::common::StripPrefixError;
 use crate::convert::TryAsRef;
@@ -488,7 +490,8 @@ impl<'a> Utf8TypedPath<'a> {
     /// let path = cwd.join("a/b/../c/./d");
     /// assert_eq!(path.absolutize().unwrap(), cwd.join("a/c/d"));
     /// ```
-    pub fn absolutize(&self) -> io::Result<Utf8TypedPathBuf> {
+    #[cfg(feature = "std")]
+    pub fn absolutize(&self) -> std::io::Result<Utf8TypedPathBuf> {
         Ok(match self {
             Self::Unix(path) => Utf8TypedPathBuf::Unix(path.absolutize()?),
             Self::Windows(path) => Utf8TypedPathBuf::Windows(path.absolutize()?),
@@ -705,6 +708,7 @@ impl TryAsRef<Utf8WindowsPath> for Utf8TypedPath<'_> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> TryAsRef<Path> for Utf8TypedPath<'a> {
     fn try_as_ref(&self) -> Option<&Path> {
         match self {

--- a/src/typed/utf8/pathbuf.rs
+++ b/src/typed/utf8/pathbuf.rs
@@ -1,10 +1,12 @@
-use std::collections::TryReserveError;
-use std::convert::TryFrom;
-use std::fmt;
-use std::io;
+use alloc::collections::TryReserveError;
+use core::convert::TryFrom;
+use core::fmt;
+
+#[cfg(feature = "std")]
 use std::path::PathBuf;
 
 use crate::common::StripPrefixError;
+use crate::no_std_compat::*;
 use crate::typed::{
     PathType, Utf8TypedAncestors, Utf8TypedComponents, Utf8TypedIter, Utf8TypedPath,
 };
@@ -708,7 +710,8 @@ impl Utf8TypedPathBuf {
     /// let path = cwd.join("a/b/../c/./d");
     /// assert_eq!(path.absolutize().unwrap(), cwd.join("a/c/d"));
     /// ```
-    pub fn absolutize(&self) -> io::Result<Utf8TypedPathBuf> {
+    #[cfg(feature = "std")]
+    pub fn absolutize(&self) -> std::io::Result<Utf8TypedPathBuf> {
         self.to_path().absolutize()
     }
 
@@ -924,6 +927,7 @@ impl TryFrom<Utf8TypedPathBuf> for Utf8WindowsPathBuf {
     }
 }
 
+#[cfg(feature = "std")]
 impl TryFrom<Utf8TypedPathBuf> for PathBuf {
     type Error = Utf8TypedPathBuf;
 

--- a/src/unix/non_utf8.rs
+++ b/src/unix/non_utf8.rs
@@ -1,11 +1,12 @@
 mod components;
 
-use std::fmt;
-use std::hash::Hasher;
+use core::fmt;
+use core::hash::Hasher;
 
 pub use components::*;
 
 use super::constants::*;
+use crate::no_std_compat::*;
 use crate::typed::{TypedPath, TypedPathBuf};
 use crate::{private, Components, Encoding, Path, PathBuf};
 

--- a/src/unix/non_utf8/components.rs
+++ b/src/unix/non_utf8/components.rs
@@ -1,7 +1,7 @@
 mod component;
 mod parser;
 
-use std::{cmp, fmt, iter};
+use core::{cmp, fmt, iter};
 
 pub use component::*;
 use parser::Parser;

--- a/src/unix/non_utf8/components/parser.rs
+++ b/src/unix/non_utf8/components/parser.rs
@@ -195,6 +195,7 @@ fn separator(input: ParseInput) -> ParseResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::no_std_compat::*;
 
     fn sep(cnt: usize) -> Vec<u8> {
         let mut v = Vec::new();

--- a/src/unix/utf8.rs
+++ b/src/unix/utf8.rs
@@ -1,10 +1,11 @@
 mod components;
 
-use std::fmt;
-use std::hash::Hasher;
+use core::fmt;
+use core::hash::Hasher;
 
 pub use components::*;
 
+use crate::no_std_compat::*;
 use crate::typed::{Utf8TypedPath, Utf8TypedPathBuf};
 use crate::{private, Encoding, UnixEncoding, Utf8Encoding, Utf8Path, Utf8PathBuf};
 

--- a/src/unix/utf8/components.rs
+++ b/src/unix/utf8/components.rs
@@ -1,6 +1,6 @@
 mod component;
 
-use std::{cmp, fmt, iter};
+use core::{cmp, fmt, iter};
 
 pub use component::*;
 
@@ -49,7 +49,7 @@ impl<'a> Utf8Components<'a> for Utf8UnixComponents<'a> {
     fn as_str(&self) -> &'a str {
         // NOTE: We know that the internal byte representation is UTF-8 compliant as we ensure that
         //       the only input provided is UTF-8 and no modifications are made with non-UTF-8 bytes
-        unsafe { std::str::from_utf8_unchecked(self.inner.as_bytes()) }
+        unsafe { core::str::from_utf8_unchecked(self.inner.as_bytes()) }
     }
 
     fn is_absolute(&self) -> bool {

--- a/src/unix/utf8/components/component.rs
+++ b/src/unix/utf8/components/component.rs
@@ -1,5 +1,5 @@
-use std::fmt;
-use std::str::Utf8Error;
+use core::fmt;
+use core::str::Utf8Error;
 
 use crate::unix::constants::{CURRENT_DIR_STR, PARENT_DIR_STR, SEPARATOR_STR};
 use crate::unix::{UnixComponent, Utf8UnixComponents};
@@ -57,7 +57,7 @@ impl<'a> Utf8UnixComponent<'a> {
             UnixComponent::RootDir => Self::RootDir,
             UnixComponent::ParentDir => Self::ParentDir,
             UnixComponent::CurDir => Self::CurDir,
-            UnixComponent::Normal(x) => Self::Normal(std::str::from_utf8(x)?),
+            UnixComponent::Normal(x) => Self::Normal(core::str::from_utf8(x)?),
         })
     }
 
@@ -93,7 +93,7 @@ impl<'a> Utf8UnixComponent<'a> {
             UnixComponent::RootDir => Self::RootDir,
             UnixComponent::ParentDir => Self::ParentDir,
             UnixComponent::CurDir => Self::CurDir,
-            UnixComponent::Normal(x) => Self::Normal(std::str::from_utf8_unchecked(x)),
+            UnixComponent::Normal(x) => Self::Normal(core::str::from_utf8_unchecked(x)),
         }
     }
 }

--- a/src/windows/non_utf8.rs
+++ b/src/windows/non_utf8.rs
@@ -1,11 +1,12 @@
 mod components;
 
-use std::fmt;
-use std::hash::{Hash, Hasher};
+use core::fmt;
+use core::hash::{Hash, Hasher};
 
 pub use components::*;
 
 use super::constants::*;
+use crate::no_std_compat::*;
 use crate::typed::{TypedPath, TypedPathBuf};
 use crate::{private, Component, Components, Encoding, Path, PathBuf};
 

--- a/src/windows/non_utf8/components.rs
+++ b/src/windows/non_utf8/components.rs
@@ -1,7 +1,7 @@
 mod component;
 mod parser;
 
-use std::{cmp, fmt, iter};
+use core::{cmp, fmt, iter};
 
 pub use component::*;
 use parser::Parser;

--- a/src/windows/non_utf8/components/component.rs
+++ b/src/windows/non_utf8/components/component.rs
@@ -1,5 +1,5 @@
 mod prefix;
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 pub use prefix::{WindowsPrefix, WindowsPrefixComponent};
 

--- a/src/windows/non_utf8/components/component/prefix.rs
+++ b/src/windows/non_utf8/components/component/prefix.rs
@@ -1,6 +1,6 @@
-use std::cmp;
-use std::convert::TryFrom;
-use std::hash::{Hash, Hasher};
+use core::cmp;
+use core::convert::TryFrom;
+use core::hash::{Hash, Hasher};
 
 use crate::windows::WindowsComponents;
 use crate::ParseError;

--- a/src/windows/non_utf8/components/parser.rs
+++ b/src/windows/non_utf8/components/parser.rs
@@ -498,7 +498,7 @@ fn drive_letter(input: ParseInput) -> ParseResult<u8> {
 mod tests {
     use super::*;
 
-    fn get_prefix<'a, E: std::fmt::Display>(
+    fn get_prefix<'a, E: alloc::fmt::Display>(
         component: impl Into<Result<WindowsComponent<'a>, E>>,
     ) -> WindowsPrefix<'a> {
         match component.into() {

--- a/src/windows/utf8.rs
+++ b/src/windows/utf8.rs
@@ -1,10 +1,11 @@
 mod components;
 
-use std::fmt;
-use std::hash::Hasher;
+use core::fmt;
+use core::hash::Hasher;
 
 pub use components::*;
 
+use crate::no_std_compat::*;
 use crate::typed::{Utf8TypedPath, Utf8TypedPathBuf};
 use crate::{private, Encoding, Utf8Encoding, Utf8Path, Utf8PathBuf, WindowsEncoding};
 

--- a/src/windows/utf8/components.rs
+++ b/src/windows/utf8/components.rs
@@ -1,6 +1,6 @@
 mod component;
 
-use std::{cmp, fmt, iter};
+use core::{cmp, fmt, iter};
 
 pub use component::*;
 
@@ -50,7 +50,7 @@ impl<'a> Utf8Components<'a> for Utf8WindowsComponents<'a> {
     fn as_str(&self) -> &'a str {
         // NOTE: We know that the internal byte representation is UTF-8 compliant as we ensure that
         //       the only input provided is UTF-8 and no modifications are made with non-UTF-8 bytes
-        unsafe { std::str::from_utf8_unchecked(self.inner.as_bytes()) }
+        unsafe { core::str::from_utf8_unchecked(self.inner.as_bytes()) }
     }
 
     /// Returns true only if the path represented by the components

--- a/src/windows/utf8/components/component.rs
+++ b/src/windows/utf8/components/component.rs
@@ -1,7 +1,7 @@
 mod prefix;
-use std::convert::TryFrom;
-use std::fmt;
-use std::str::Utf8Error;
+use core::convert::TryFrom;
+use core::fmt;
+use core::str::Utf8Error;
 
 pub use prefix::{Utf8WindowsPrefix, Utf8WindowsPrefixComponent};
 
@@ -73,7 +73,7 @@ impl<'a> Utf8WindowsComponent<'a> {
             WindowsComponent::RootDir => Self::RootDir,
             WindowsComponent::ParentDir => Self::ParentDir,
             WindowsComponent::CurDir => Self::CurDir,
-            WindowsComponent::Normal(x) => Self::Normal(std::str::from_utf8(x)?),
+            WindowsComponent::Normal(x) => Self::Normal(core::str::from_utf8(x)?),
         })
     }
 
@@ -112,7 +112,7 @@ impl<'a> Utf8WindowsComponent<'a> {
             WindowsComponent::RootDir => Self::RootDir,
             WindowsComponent::ParentDir => Self::ParentDir,
             WindowsComponent::CurDir => Self::CurDir,
-            WindowsComponent::Normal(x) => Self::Normal(std::str::from_utf8_unchecked(x)),
+            WindowsComponent::Normal(x) => Self::Normal(core::str::from_utf8_unchecked(x)),
         }
     }
 

--- a/src/windows/utf8/components/component/prefix.rs
+++ b/src/windows/utf8/components/component/prefix.rs
@@ -1,7 +1,7 @@
-use std::cmp;
-use std::convert::TryFrom;
-use std::hash::{Hash, Hasher};
-use std::str::Utf8Error;
+use core::cmp;
+use core::convert::TryFrom;
+use core::hash::{Hash, Hasher};
+use core::str::Utf8Error;
 
 use crate::windows::{Utf8WindowsComponents, WindowsPrefix, WindowsPrefixComponent};
 use crate::ParseError;
@@ -112,7 +112,7 @@ impl<'a> Utf8WindowsPrefixComponent<'a> {
     /// errors that can be returned.
     pub fn from_utf8(component: &WindowsPrefixComponent<'a>) -> Result<Self, Utf8Error> {
         Ok(Self {
-            raw: std::str::from_utf8(component.raw)?,
+            raw: core::str::from_utf8(component.raw)?,
             parsed: Utf8WindowsPrefix::from_utf8(&component.parsed)?,
         })
     }
@@ -129,7 +129,7 @@ impl<'a> Utf8WindowsPrefixComponent<'a> {
     /// [`from_utf8`]: Utf8WindowsPrefixComponent::from_utf8
     pub unsafe fn from_utf8_unchecked(component: &WindowsPrefixComponent<'a>) -> Self {
         Self {
-            raw: std::str::from_utf8_unchecked(component.raw),
+            raw: core::str::from_utf8_unchecked(component.raw),
             parsed: Utf8WindowsPrefix::from_utf8_unchecked(&component.parsed),
         }
     }
@@ -363,13 +363,15 @@ impl<'a> Utf8WindowsPrefix<'a> {
     /// errors that can be returned.
     pub fn from_utf8(prefix: &WindowsPrefix<'a>) -> Result<Self, Utf8Error> {
         Ok(match prefix {
-            WindowsPrefix::Verbatim(x) => Self::Verbatim(std::str::from_utf8(x)?),
+            WindowsPrefix::Verbatim(x) => Self::Verbatim(core::str::from_utf8(x)?),
             WindowsPrefix::VerbatimUNC(x, y) => {
-                Self::VerbatimUNC(std::str::from_utf8(x)?, std::str::from_utf8(y)?)
+                Self::VerbatimUNC(core::str::from_utf8(x)?, core::str::from_utf8(y)?)
             }
             WindowsPrefix::VerbatimDisk(x) => Self::VerbatimDisk(*x as char),
-            WindowsPrefix::UNC(x, y) => Self::UNC(std::str::from_utf8(x)?, std::str::from_utf8(y)?),
-            WindowsPrefix::DeviceNS(x) => Self::DeviceNS(std::str::from_utf8(x)?),
+            WindowsPrefix::UNC(x, y) => {
+                Self::UNC(core::str::from_utf8(x)?, core::str::from_utf8(y)?)
+            }
+            WindowsPrefix::DeviceNS(x) => Self::DeviceNS(core::str::from_utf8(x)?),
             WindowsPrefix::Disk(x) => Self::Disk(*x as char),
         })
     }
@@ -386,17 +388,17 @@ impl<'a> Utf8WindowsPrefix<'a> {
     /// [`from_utf8`]: Utf8WindowsPrefix::from_utf8
     pub unsafe fn from_utf8_unchecked(prefix: &WindowsPrefix<'a>) -> Self {
         match prefix {
-            WindowsPrefix::Verbatim(x) => Self::Verbatim(std::str::from_utf8_unchecked(x)),
+            WindowsPrefix::Verbatim(x) => Self::Verbatim(core::str::from_utf8_unchecked(x)),
             WindowsPrefix::VerbatimUNC(x, y) => Self::VerbatimUNC(
-                std::str::from_utf8_unchecked(x),
-                std::str::from_utf8_unchecked(y),
+                core::str::from_utf8_unchecked(x),
+                core::str::from_utf8_unchecked(y),
             ),
             WindowsPrefix::VerbatimDisk(x) => Self::VerbatimDisk(*x as char),
             WindowsPrefix::UNC(x, y) => Self::UNC(
-                std::str::from_utf8_unchecked(x),
-                std::str::from_utf8_unchecked(y),
+                core::str::from_utf8_unchecked(x),
+                core::str::from_utf8_unchecked(y),
             ),
-            WindowsPrefix::DeviceNS(x) => Self::DeviceNS(std::str::from_utf8_unchecked(x)),
+            WindowsPrefix::DeviceNS(x) => Self::DeviceNS(core::str::from_utf8_unchecked(x)),
             WindowsPrefix::Disk(x) => Self::Disk(*x as char),
         }
     }


### PR DESCRIPTION
Hey there, wonderful crate!

I'm trying to build filesystem abstractions that do not depend on the standard library (i.e. could be embedded into no_std kernel and alike), and `std::path::Path(Buf)` strictly depend on existence of standard library. Funnily enough, there don't seem to be any no_std path implementations. However, this crate seems like a good candidate, because it does not merely wrap path objects, but reimplements them!

This PR divorces the codebase from `std`, and only makes it depend on `alloc`, with optional dependency to `std`. I suppose `alloc` could be void too if one were to feature gate `PathBuf`, but I don't think it's worth to do it all in one go (or at all).

Please let me know what you think, whether this seems like a reasonable change, and if there are any changes you'd like to see.