### PR TITLE
Introduce checked functions for pushing, joining, and switching encodings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add `join_checked` function, which ensures that any path joied with an existing path follows the rules of `push_checked`
 * Add `with_encoding_checked` function to ensure that the resulting path from an encoding conversion is still valid
 * Add `with_unix_encoding_checked` and `with_windows_encoding_checked` functions as shortcuts to `with_encoding_checked`
+* Add `is_valid` to `Component` and `Utf8Component` traits alongside `Path` and `Utf8Path` to indicate if a component/path is valid for the given encoding
 
 ## [0.7.1] - 2024-02-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2024-02-24
+
+* Add `push_checked` function, which ensures that any path added to an existing `PathBuf` or `TypedPathBuf` must abide by the following rules:
+    1. It cannot be an absolute path. Only relative paths allowed.
+    2. In the case of Windows, it cannot start with a prefix like `C:`.
+    3. All normal components of the path must contain only valid characters.
+    4. If parent directory (..) components are present, they must not result in a path traversal attack (impacting the current path).
+* Add `join_checked` function, which ensures that any path joied with an existing path follows the rules of `push_checked`
+* Add `with_encoding_checked` function to ensure that the resulting path from an encoding conversion is still valid
+* Add `with_unix_encoding_checked` and `with_windows_encoding_checked` functions as shortcuts to `with_encoding_checked`
+
 ## [0.7.1] - 2024-02-15
 
 * Support `wasm` family for compilation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "typed-path"
 description = "Provides typed variants of Path and PathBuf for Unix and Windows"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 authors = ["Chip Senkbeil <chip@senkbeil.org>"]
 categories = ["development-tools", "filesystem", "os"]

--- a/src/common/errors.rs
+++ b/src/common/errors.rs
@@ -18,3 +18,34 @@ impl fmt::Display for StripPrefixError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for StripPrefixError {}
+
+/// An error returned when a path violates checked criteria.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CheckedPathError {
+    /// When a normal component contains invalid characters for the current encoding.
+    InvalidFilename,
+
+    /// When a path component that represents a parent directory is provided such that the original
+    /// path would be escaped to access arbitrary files.
+    PathTraversalAttack,
+
+    /// When a path component that represents a prefix is provided after the start of the path.
+    UnexpectedPrefix,
+
+    /// When a path component that represents a root is provided after the start of the path.
+    UnexpectedRoot,
+}
+
+impl fmt::Display for CheckedPathError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidFilename => write!(f, "path contains invalid filename"),
+            Self::PathTraversalAttack => write!(f, "path attempts to escape original path"),
+            Self::UnexpectedPrefix => write!(f, "path contains unexpected prefix"),
+            Self::UnexpectedRoot => write!(f, "path contains unexpected root"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for CheckedPathError {}

--- a/src/common/non_utf8.rs
+++ b/src/common/non_utf8.rs
@@ -14,6 +14,7 @@ pub use parser::ParseError;
 pub use path::*;
 pub use pathbuf::*;
 
+use crate::common::errors::CheckedPathError;
 use crate::no_std_compat::*;
 use crate::private;
 
@@ -33,4 +34,12 @@ pub trait Encoding<'a>: private::Sealed {
 
     /// Pushes a byte slice (`path`) onto the an existing path (`current_path`)
     fn push(current_path: &mut Vec<u8>, path: &[u8]);
+
+    /// Like [`Encoding::push`], but enforces several new rules:
+    ///
+    /// 1. `path` cannot contain a prefix component.
+    /// 2. `path` cannot contain a root component.
+    /// 3. `path` cannot contain invalid filename bytes.
+    /// 4. `path` cannot contain parent components such that the current path would be escaped.
+    fn push_checked(current_path: &mut Vec<u8>, path: &[u8]) -> Result<(), CheckedPathError>;
 }

--- a/src/common/non_utf8/components/component.rs
+++ b/src/common/non_utf8/components/component.rs
@@ -64,6 +64,28 @@ pub trait Component<'a>:
     /// * `UnixComponent::Normal("here.txt")` - `is_current() == false`
     fn is_current(&self) -> bool;
 
+    /// Returns true if this component is valid. A component can only be invalid if it represents a
+    /// normal component with bytes that are disallowed by the encoding.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Component, UnixComponent, WindowsComponent};
+    ///
+    /// assert!(UnixComponent::RootDir.is_valid());
+    /// assert!(UnixComponent::ParentDir.is_valid());
+    /// assert!(UnixComponent::CurDir.is_valid());
+    /// assert!(UnixComponent::Normal(b"abc").is_valid());
+    /// assert!(!UnixComponent::Normal(b"\0").is_valid());
+    ///
+    /// assert!(WindowsComponent::RootDir.is_valid());
+    /// assert!(WindowsComponent::ParentDir.is_valid());
+    /// assert!(WindowsComponent::CurDir.is_valid());
+    /// assert!(WindowsComponent::Normal(b"abc").is_valid());
+    /// assert!(!WindowsComponent::Normal(b"|").is_valid());
+    /// ```
+    fn is_valid(&self) -> bool;
+
     /// Returns size of component in bytes
     fn len(&self) -> usize;
 

--- a/src/common/non_utf8/path.rs
+++ b/src/common/non_utf8/path.rs
@@ -256,7 +256,7 @@ where
 
     /// Returns `true` if the path is valid, meaning that all of its components are valid.
     ///
-    /// See [`Encoding::is_valid`]'s documentation for more details.
+    /// See [`Component::is_valid`]'s documentation for more details.
     ///
     /// # Examples
     ///
@@ -268,7 +268,7 @@ where
     /// assert!(!Path::<UnixEncoding>::new("foo\0.txt").is_valid());
     /// ```
     ///
-    /// [`Encoding::is_valid`]: crate::Encoding::is_valid
+    /// [`Component::is_valid`]: crate::Component::is_valid
     pub fn is_valid(&self) -> bool {
         self.components().all(|c| c.is_valid())
     }

--- a/src/common/non_utf8/path.rs
+++ b/src/common/non_utf8/path.rs
@@ -254,6 +254,25 @@ where
         !self.is_absolute()
     }
 
+    /// Returns `true` if the path is valid, meaning that all of its components are valid.
+    ///
+    /// See [`Encoding::is_valid`]'s documentation for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Path, UnixEncoding};
+    ///
+    /// // NOTE: A path cannot be created on its own without a defined encoding
+    /// assert!(Path::<UnixEncoding>::new("foo.txt").is_valid());
+    /// assert!(!Path::<UnixEncoding>::new("foo\0.txt").is_valid());
+    /// ```
+    ///
+    /// [`Encoding::is_valid`]: crate::Encoding::is_valid
+    pub fn is_valid(&self) -> bool {
+        self.components().all(|c| c.is_valid())
+    }
+
     /// Returns `true` if the `Path` has a root.
     ///
     /// * On Unix ([`UnixPath`]), a path has a root if it begins with `/`.

--- a/src/common/non_utf8/pathbuf.rs
+++ b/src/common/non_utf8/pathbuf.rs
@@ -9,7 +9,7 @@ use core::str::FromStr;
 use core::{cmp, fmt};
 
 use crate::no_std_compat::*;
-use crate::{Encoding, Iter, Path};
+use crate::{CheckedPathError, Encoding, Iter, Path};
 
 /// An owned, mutable path that mirrors [`std::path::PathBuf`], but operatings using an
 /// [`Encoding`] to determine how to parse the underlying bytes.
@@ -173,6 +173,63 @@ where
     /// ```
     pub fn push<P: AsRef<Path<T>>>(&mut self, path: P) {
         T::push(&mut self.inner, path.as_ref().as_bytes());
+    }
+
+    /// Like [`PathBuf::push`], extends `self` with `path`, but also checks to ensure that `path`
+    /// abides by a set of rules.
+    ///
+    /// # Rules
+    ///
+    /// 1. `path` cannot contain a prefix component.
+    /// 2. `path` cannot contain a root component.
+    /// 3. `path` cannot contain invalid filename bytes.
+    /// 4. `path` cannot contain parent components such that the current path would be escaped.
+    ///
+    /// # Examples
+    ///
+    /// Pushing a relative path extends the existing path:
+    ///
+    /// ```
+    /// use typed_path::{PathBuf, UnixEncoding};
+    ///
+    /// // NOTE: A pathbuf cannot be created on its own without a defined encoding
+    /// let mut path = PathBuf::<UnixEncoding>::from("/tmp");
+    ///
+    /// // Pushing a relative path works like normal
+    /// assert!(path.push_checked("file.bk").is_ok());
+    /// assert_eq!(path, PathBuf::from("/tmp/file.bk"));
+    /// ```
+    ///
+    /// Pushing a relative path that contains unresolved parent directory references fails
+    /// with an error:
+    ///
+    /// ```
+    /// use typed_path::{CheckedPathError, PathBuf, UnixEncoding};
+    ///
+    /// // NOTE: A pathbuf cannot be created on its own without a defined encoding
+    /// let mut path = PathBuf::<UnixEncoding>::from("/tmp");
+    ///
+    /// // Pushing a relative path that contains parent directory references that cannot be
+    /// // resolved within the path is considered an error as this is considered a path
+    /// // traversal attack!
+    /// assert_eq!(path.push_checked(".."), Err(CheckedPathError::PathTraversalAttack));
+    /// assert_eq!(path, PathBuf::from("/tmp"));
+    /// ```
+    ///
+    /// Pushing an absolute path fails with an error:
+    ///
+    /// ```
+    /// use typed_path::{CheckedPathError, PathBuf, UnixEncoding};
+    ///
+    /// // NOTE: A pathbuf cannot be created on its own without a defined encoding
+    /// let mut path = PathBuf::<UnixEncoding>::from("/tmp");
+    ///
+    /// // Pushing an absolute path will fail with an error
+    /// assert_eq!(path.push_checked("/etc"), Err(CheckedPathError::UnexpectedRoot));
+    /// assert_eq!(path, PathBuf::from("/tmp"));
+    /// ```
+    pub fn push_checked<P: AsRef<Path<T>>>(&mut self, path: P) -> Result<(), CheckedPathError> {
+        T::push_checked(&mut self.inner, path.as_ref().as_bytes())
     }
 
     /// Truncates `self` to [`self.parent`].

--- a/src/common/utf8.rs
+++ b/src/common/utf8.rs
@@ -10,6 +10,7 @@ pub use iter::*;
 pub use path::*;
 pub use pathbuf::*;
 
+use crate::common::errors::CheckedPathError;
 use crate::no_std_compat::*;
 use crate::private;
 
@@ -29,4 +30,12 @@ pub trait Utf8Encoding<'a>: private::Sealed {
 
     /// Pushes a utf8 str (`path`) onto the an existing path (`current_path`)
     fn push(current_path: &mut String, path: &str);
+
+    /// Like [`Utf8Encoding::push`], but enforces several new rules:
+    ///
+    /// 1. `path` cannot contain a prefix component.
+    /// 2. `path` cannot contain a root component.
+    /// 3. `path` cannot contain invalid filename characters.
+    /// 4. `path` cannot contain parent components such that the current path would be escaped.
+    fn push_checked(current_path: &mut String, path: &str) -> Result<(), CheckedPathError>;
 }

--- a/src/common/utf8/components/component.rs
+++ b/src/common/utf8/components/component.rs
@@ -21,10 +21,10 @@ pub trait Utf8Component<'a>:
     ///
     /// `/my/../path/./here.txt` has the components on Unix of
     ///
-    /// * `UnixComponent::RootDir` - `is_root() == true`
-    /// * `UnixComponent::ParentDir` - `is_root() == false`
-    /// * `UnixComponent::CurDir` - `is_root() == false`
-    /// * `UnixComponent::Normal("here.txt")` - `is_root() == false`
+    /// * `Utf8UnixComponent::RootDir` - `is_root() == true`
+    /// * `Utf8UnixComponent::ParentDir` - `is_root() == false`
+    /// * `Utf8UnixComponent::CurDir` - `is_root() == false`
+    /// * `Utf8UnixComponent::Normal("here.txt")` - `is_root() == false`
     fn is_root(&self) -> bool;
 
     /// Returns true if this component represents a normal part of the path
@@ -33,10 +33,10 @@ pub trait Utf8Component<'a>:
     ///
     /// `/my/../path/./here.txt` has the components on Unix of
     ///
-    /// * `UnixComponent::RootDir` - `is_normal() == false`
-    /// * `UnixComponent::ParentDir` - `is_normal() == false`
-    /// * `UnixComponent::CurDir` - `is_normal() == false`
-    /// * `UnixComponent::Normal("here.txt")` - `is_normal() == true`
+    /// * `Utf8UnixComponent::RootDir` - `is_normal() == false`
+    /// * `Utf8UnixComponent::ParentDir` - `is_normal() == false`
+    /// * `Utf8UnixComponent::CurDir` - `is_normal() == false`
+    /// * `Utf8UnixComponent::Normal("here.txt")` - `is_normal() == true`
     fn is_normal(&self) -> bool;
 
     /// Returns true if this component represents a relative representation of a parent directory
@@ -45,10 +45,10 @@ pub trait Utf8Component<'a>:
     ///
     /// `/my/../path/./here.txt` has the components on Unix of
     ///
-    /// * `UnixComponent::RootDir` - `is_parent() == false`
-    /// * `UnixComponent::ParentDir` - `is_parent() == true`
-    /// * `UnixComponent::CurDir` - `is_parent() == false`
-    /// * `UnixComponent::Normal("here.txt")` - `is_parent() == false`
+    /// * `Utf8UnixComponent::RootDir` - `is_parent() == false`
+    /// * `Utf8UnixComponent::ParentDir` - `is_parent() == true`
+    /// * `Utf8UnixComponent::CurDir` - `is_parent() == false`
+    /// * `Utf8UnixComponent::Normal("here.txt")` - `is_parent() == false`
     fn is_parent(&self) -> bool;
 
     /// Returns true if this component represents a relative representation of the current
@@ -58,11 +58,33 @@ pub trait Utf8Component<'a>:
     ///
     /// `/my/../path/./here.txt` has the components on Unix of
     ///
-    /// * `UnixComponent::RootDir` - `is_current() == false`
-    /// * `UnixComponent::ParentDir` - `is_current() == false`
-    /// * `UnixComponent::CurDir` - `is_current() == true`
-    /// * `UnixComponent::Normal("here.txt")` - `is_current() == false`
+    /// * `Utf8UnixComponent::RootDir` - `is_current() == false`
+    /// * `Utf8UnixComponent::ParentDir` - `is_current() == false`
+    /// * `Utf8UnixComponent::CurDir` - `is_current() == true`
+    /// * `Utf8UnixComponent::Normal("here.txt")` - `is_current() == false`
     fn is_current(&self) -> bool;
+
+    /// Returns true if this component is valid. A component can only be invalid if it represents a
+    /// normal component with characters that are disallowed by the encoding.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Utf8Component, Utf8UnixComponent, Utf8WindowsComponent};
+    ///
+    /// assert!(Utf8UnixComponent::RootDir.is_valid());
+    /// assert!(Utf8UnixComponent::ParentDir.is_valid());
+    /// assert!(Utf8UnixComponent::CurDir.is_valid());
+    /// assert!(Utf8UnixComponent::Normal("abc").is_valid());
+    /// assert!(!Utf8UnixComponent::Normal("\0").is_valid());
+    ///
+    /// assert!(Utf8WindowsComponent::RootDir.is_valid());
+    /// assert!(Utf8WindowsComponent::ParentDir.is_valid());
+    /// assert!(Utf8WindowsComponent::CurDir.is_valid());
+    /// assert!(Utf8WindowsComponent::Normal("abc").is_valid());
+    /// assert!(!Utf8WindowsComponent::Normal("|").is_valid());
+    /// ```
+    fn is_valid(&self) -> bool;
 
     /// Returns size of component in bytes
     fn len(&self) -> usize;

--- a/src/common/utf8/path.rs
+++ b/src/common/utf8/path.rs
@@ -206,7 +206,7 @@ where
 
     /// Returns `true` if the path is valid, meaning that all of its components are valid.
     ///
-    /// See [`Utf8Encoding::is_valid`]'s documentation for more details.
+    /// See [`Utf8Component::is_valid`]'s documentation for more details.
     ///
     /// # Examples
     ///
@@ -218,7 +218,7 @@ where
     /// assert!(!Utf8Path::<Utf8UnixEncoding>::new("foo\0.txt").is_valid());
     /// ```
     ///
-    /// [`Utf8Encoding::is_valid`]: crate::Utf8Encoding::is_valid
+    /// [`Utf8Component::is_valid`]: crate::Utf8Component::is_valid
     pub fn is_valid(&self) -> bool {
         self.components().all(|c| c.is_valid())
     }

--- a/src/common/utf8/path.rs
+++ b/src/common/utf8/path.rs
@@ -204,6 +204,25 @@ where
         !self.is_absolute()
     }
 
+    /// Returns `true` if the path is valid, meaning that all of its components are valid.
+    ///
+    /// See [`Utf8Encoding::is_valid`]'s documentation for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{Utf8Path, Utf8UnixEncoding};
+    ///
+    /// // NOTE: A path cannot be created on its own without a defined encoding
+    /// assert!(Utf8Path::<Utf8UnixEncoding>::new("foo.txt").is_valid());
+    /// assert!(!Utf8Path::<Utf8UnixEncoding>::new("foo\0.txt").is_valid());
+    /// ```
+    ///
+    /// [`Utf8Encoding::is_valid`]: crate::Utf8Encoding::is_valid
+    pub fn is_valid(&self) -> bool {
+        self.components().all(|c| c.is_valid())
+    }
+
     /// Returns `true` if the `Utf8Path` has a root.
     ///
     /// * On Unix ([`Utf8UnixPath`]), a path has a root if it begins with `/`.

--- a/src/typed/non_utf8/path.rs
+++ b/src/typed/non_utf8/path.rs
@@ -777,12 +777,30 @@ impl<'a> TypedPath<'a> {
         }
     }
 
-    /// Converts this [`TypedPath`] into the Unix variant of [`TypedPathBuf`].
+    /// Converts this [`TypedPath`] into the Unix variant of [`TypedPathBuf`], ensuring it is a
+    /// valid Unix path.
+    pub fn with_unix_encoding_checked(&self) -> Result<TypedPathBuf, CheckedPathError> {
+        Ok(match self {
+            Self::Unix(p) => TypedPathBuf::Unix(p.with_unix_encoding_checked()?),
+            Self::Windows(p) => TypedPathBuf::Unix(p.with_unix_encoding_checked()?),
+        })
+    }
+
+    /// Converts this [`TypedPath`] into the Windows variant of [`TypedPathBuf`].
     pub fn with_windows_encoding(&self) -> TypedPathBuf {
         match self {
             Self::Unix(p) => TypedPathBuf::Windows(p.with_windows_encoding()),
             _ => self.to_path_buf(),
         }
+    }
+
+    /// Converts this [`TypedPath`] into the Windows variant of [`TypedPathBuf`], ensuring it is a
+    /// valid Windows path.
+    pub fn with_windows_encoding_checked(&self) -> Result<TypedPathBuf, CheckedPathError> {
+        Ok(match self {
+            Self::Unix(p) => TypedPathBuf::Windows(p.with_windows_encoding_checked()?),
+            Self::Windows(p) => TypedPathBuf::Windows(p.with_windows_encoding_checked()?),
+        })
     }
 }
 

--- a/src/typed/non_utf8/pathbuf.rs
+++ b/src/typed/non_utf8/pathbuf.rs
@@ -42,12 +42,29 @@ impl TypedPathBuf {
         }
     }
 
-    /// Converts this [`TypedPathBuf`] into the Unix variant.
+    /// Converts this [`TypedPathBuf`] into the Unix variant, ensuring it is a valid Unix path.
+    pub fn with_unix_encoding_checked(&self) -> Result<TypedPathBuf, CheckedPathError> {
+        Ok(match self {
+            Self::Unix(p) => TypedPathBuf::Unix(p.with_unix_encoding_checked()?),
+            Self::Windows(p) => TypedPathBuf::Unix(p.with_unix_encoding_checked()?),
+        })
+    }
+
+    /// Converts this [`TypedPathBuf`] into the Windows variant.
     pub fn with_windows_encoding(&self) -> TypedPathBuf {
         match self {
             Self::Unix(p) => TypedPathBuf::Windows(p.with_windows_encoding()),
             _ => self.clone(),
         }
+    }
+
+    /// Converts this [`TypedPathBuf`] into the Windows variant, ensuring it is a valid Windows
+    /// path.
+    pub fn with_windows_encoding_checked(&self) -> Result<TypedPathBuf, CheckedPathError> {
+        Ok(match self {
+            Self::Unix(p) => TypedPathBuf::Windows(p.with_windows_encoding_checked()?),
+            Self::Windows(p) => TypedPathBuf::Windows(p.with_windows_encoding_checked()?),
+        })
     }
 
     /// Allocates an empty [`TypedPathBuf`] for the specified path type.

--- a/src/typed/non_utf8/pathbuf.rs
+++ b/src/typed/non_utf8/pathbuf.rs
@@ -842,6 +842,41 @@ impl TypedPathBuf {
         self.to_path().join(path)
     }
 
+    /// Creates an owned [`TypedPathBuf`] with `path` adjoined to `self`, checking the `path` to
+    /// ensure it is safe to join. _When dealing with user-provided paths, this is the preferred
+    /// method._
+    ///
+    /// See [`TypedPathBuf::push_checked`] for more details on what it means to adjoin a path
+    /// safely.
+    ///
+    /// # Difference from Path
+    ///
+    /// Unlike [`Path::join_checked`], this implementation only supports types that implement
+    /// `AsRef<[u8]>` instead of `AsRef<Path>`.
+    ///
+    /// [`Path::join_checked`]: crate::Path::join_checked
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{CheckedPathError, TypedPathBuf};
+    ///
+    /// // Valid path will join successfully
+    /// assert_eq!(
+    ///     TypedPathBuf::from("/etc").join_checked("passwd"),
+    ///     Ok(TypedPathBuf::from("/etc/passwd")),
+    /// );
+    ///
+    /// // Invalid path will fail to join
+    /// assert_eq!(
+    ///     TypedPathBuf::from("/etc").join_checked("/sneaky/path"),
+    ///     Err(CheckedPathError::UnexpectedRoot),
+    /// );
+    /// ```
+    pub fn join_checked(&self, path: impl AsRef<[u8]>) -> Result<TypedPathBuf, CheckedPathError> {
+        self.to_path().join_checked(path)
+    }
+
     /// Creates an owned [`TypedPathBuf`] like `self` but with the given file name.
     ///
     /// See [`TypedPathBuf::set_file_name`] for more details.

--- a/src/typed/utf8/path.rs
+++ b/src/typed/utf8/path.rs
@@ -3,7 +3,7 @@ use core::fmt;
 #[cfg(feature = "std")]
 use std::path::Path;
 
-use crate::common::StripPrefixError;
+use crate::common::{CheckedPathError, StripPrefixError};
 use crate::convert::TryAsRef;
 use crate::typed::{
     PathType, Utf8TypedAncestors, Utf8TypedComponents, Utf8TypedIter, Utf8TypedPathBuf,
@@ -504,10 +504,10 @@ impl<'a> Utf8TypedPath<'a> {
     ///
     /// # Difference from Path
     ///
-    /// Unlike [`Path::join`], this implementation only supports types that implement
+    /// Unlike [`Utf8Path::join`], this implementation only supports types that implement
     /// `AsRef<str>` instead of `AsRef<Path>`.
     ///
-    /// [`Path::join`]: crate::Path::join
+    /// [`Utf8Path::join`]: crate::Utf8Path::join
     ///
     /// # Examples
     ///
@@ -524,6 +524,47 @@ impl<'a> Utf8TypedPath<'a> {
             Self::Unix(p) => Utf8TypedPathBuf::Unix(p.join(Utf8UnixPath::new(&path))),
             Self::Windows(p) => Utf8TypedPathBuf::Windows(p.join(Utf8WindowsPath::new(&path))),
         }
+    }
+
+    /// Creates an owned [`Utf8TypedPathBuf`] with `path` adjoined to `self`, checking the `path` to
+    /// ensure it is safe to join. _When dealing with user-provided paths, this is the preferred
+    /// method._
+    ///
+    /// See [`Utf8TypedPathBuf::push_checked`] for more details on what it means to adjoin a path
+    /// safely.
+    ///
+    /// # Difference from Path
+    ///
+    /// Unlike [`Utf8Path::join_checked`], this implementation only supports types that implement
+    /// `AsRef<str>` instead of `AsRef<Path>`.
+    ///
+    /// [`Utf8Path::join_checked`]: crate::Utf8Path::join_checked
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{CheckedPathError, Utf8TypedPath, Utf8TypedPathBuf};
+    ///
+    /// assert_eq!(
+    ///     Utf8TypedPath::derive("/etc").join_checked("passwd"),
+    ///     Ok(Utf8TypedPathBuf::from("/etc/passwd")),
+    /// );
+    ///
+    /// assert_eq!(
+    ///     Utf8TypedPath::derive("/etc").join_checked("/sneaky/path"),
+    ///     Err(CheckedPathError::UnexpectedRoot),
+    /// );
+    /// ```
+    pub fn join_checked(
+        &self,
+        path: impl AsRef<str>,
+    ) -> Result<Utf8TypedPathBuf, CheckedPathError> {
+        Ok(match self {
+            Self::Unix(p) => Utf8TypedPathBuf::Unix(p.join_checked(Utf8UnixPath::new(&path))?),
+            Self::Windows(p) => {
+                Utf8TypedPathBuf::Windows(p.join_checked(Utf8WindowsPath::new(&path))?)
+            }
+        })
     }
 
     /// Creates an owned [`Utf8TypedPathBuf`] like `self` but with the given file name.

--- a/src/typed/utf8/path.rs
+++ b/src/typed/utf8/path.rs
@@ -699,12 +699,30 @@ impl<'a> Utf8TypedPath<'a> {
         }
     }
 
-    /// Converts this [`Utf8TypedPath`] into the Unix variant of [`Utf8TypedPathBuf`].
+    /// Converts this [`Utf8TypedPath`] into the Unix variant of [`Utf8TypedPathBuf`], ensuring it
+    /// is a valid Unix path.
+    pub fn with_unix_encoding_checked(&self) -> Result<Utf8TypedPathBuf, CheckedPathError> {
+        Ok(match self {
+            Self::Unix(p) => Utf8TypedPathBuf::Unix(p.with_unix_encoding_checked()?),
+            Self::Windows(p) => Utf8TypedPathBuf::Unix(p.with_unix_encoding_checked()?),
+        })
+    }
+
+    /// Converts this [`Utf8TypedPath`] into the Windows variant of [`Utf8TypedPathBuf`].
     pub fn with_windows_encoding(&self) -> Utf8TypedPathBuf {
         match self {
             Self::Unix(p) => Utf8TypedPathBuf::Windows(p.with_windows_encoding()),
             _ => self.to_path_buf(),
         }
+    }
+
+    /// Converts this [`Utf8TypedPath`] into the Windows variant of [`Utf8TypedPathBuf`], ensuring
+    /// it is a valid Windows path.
+    pub fn with_windows_encoding_checked(&self) -> Result<Utf8TypedPathBuf, CheckedPathError> {
+        Ok(match self {
+            Self::Unix(p) => Utf8TypedPathBuf::Windows(p.with_windows_encoding_checked()?),
+            Self::Windows(p) => Utf8TypedPathBuf::Windows(p.with_windows_encoding_checked()?),
+        })
     }
 }
 

--- a/src/typed/utf8/pathbuf.rs
+++ b/src/typed/utf8/pathbuf.rs
@@ -44,12 +44,30 @@ impl Utf8TypedPathBuf {
         }
     }
 
-    /// Converts this [`Utf8TypedPathBuf`] into the Unix variant.
+    /// Converts this [`Utf8TypedPathBuf`] into the Unix variant, ensuring it is valid as a Unix
+    /// path.
+    pub fn with_unix_encoding_checked(&self) -> Result<Utf8TypedPathBuf, CheckedPathError> {
+        Ok(match self {
+            Self::Unix(p) => Utf8TypedPathBuf::Unix(p.with_unix_encoding_checked()?),
+            Self::Windows(p) => Utf8TypedPathBuf::Unix(p.with_unix_encoding_checked()?),
+        })
+    }
+
+    /// Converts this [`Utf8TypedPathBuf`] into the Windows variant.
     pub fn with_windows_encoding(&self) -> Utf8TypedPathBuf {
         match self {
             Self::Unix(p) => Utf8TypedPathBuf::Windows(p.with_windows_encoding()),
             _ => self.clone(),
         }
+    }
+
+    /// Converts this [`Utf8TypedPathBuf`] into the Windows variant, ensuring it is valid as a
+    /// Windows path.
+    pub fn with_windows_encoding_checked(&self) -> Result<Utf8TypedPathBuf, CheckedPathError> {
+        Ok(match self {
+            Self::Unix(p) => Utf8TypedPathBuf::Windows(p.with_windows_encoding_checked()?),
+            Self::Windows(p) => Utf8TypedPathBuf::Windows(p.with_windows_encoding_checked()?),
+        })
     }
 
     /// Allocates an empty [`Utf8TypedPathBuf`] for the specified path type.
@@ -163,7 +181,7 @@ impl Utf8TypedPathBuf {
         }
     }
 
-    /// Like [`TypedPathBuf::push`], extends `self` with `path`, but also checks to ensure that
+    /// Like [`Utf8TypedPathBuf::push`], extends `self` with `path`, but also checks to ensure that
     /// `path` abides by a set of rules.
     ///
     /// # Rules

--- a/src/typed/utf8/pathbuf.rs
+++ b/src/typed/utf8/pathbuf.rs
@@ -802,6 +802,44 @@ impl Utf8TypedPathBuf {
         self.to_path().join(path)
     }
 
+    /// Creates an owned [`Utf8TypedPathBuf`] with `path` adjoined to `self`, checking the `path`
+    /// to ensure it is safe to join. _When dealing with user-provided paths, this is the preferred
+    /// method._
+    ///
+    /// See [`Utf8TypedPathBuf::push_checked`] for more details on what it means to adjoin a path
+    /// safely.
+    ///
+    /// # Difference from Path
+    ///
+    /// Unlike [`Utf8Path::join_checked`], this implementation only supports types that implement
+    /// `AsRef<str>` instead of `AsRef<Path>`.
+    ///
+    /// [`Utf8Path::join_checked`]: crate::Utf8Path::join_checked
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::{CheckedPathError, Utf8TypedPathBuf};
+    ///
+    /// // Valid path will join successfully
+    /// assert_eq!(
+    ///     Utf8TypedPathBuf::from("/etc").join_checked("passwd"),
+    ///     Ok(Utf8TypedPathBuf::from("/etc/passwd")),
+    /// );
+    ///
+    /// // Invalid path will fail to join
+    /// assert_eq!(
+    ///     Utf8TypedPathBuf::from("/etc").join_checked("/sneaky/path"),
+    ///     Err(CheckedPathError::UnexpectedRoot),
+    /// );
+    /// ```
+    pub fn join_checked(
+        &self,
+        path: impl AsRef<str>,
+    ) -> Result<Utf8TypedPathBuf, CheckedPathError> {
+        self.to_path().join_checked(path)
+    }
+
     /// Creates an owned [`Utf8TypedPathBuf`] like `self` but with the given file name.
     ///
     /// See [`Utf8TypedPathBuf::set_file_name`] for more details.

--- a/src/unix/non_utf8.rs
+++ b/src/unix/non_utf8.rs
@@ -155,6 +155,14 @@ where
     pub fn with_unix_encoding(&self) -> PathBuf<UnixEncoding> {
         self.with_encoding()
     }
+
+    /// Creates an owned [`PathBuf`] like `self` but using [`UnixEncoding`], ensuring it is a valid
+    /// Unix path.
+    ///
+    /// See [`Path::with_encoding_checked`] for more information.
+    pub fn with_unix_encoding_checked(&self) -> Result<PathBuf<UnixEncoding>, CheckedPathError> {
+        self.with_encoding_checked()
+    }
 }
 
 impl UnixPath {

--- a/src/unix/utf8.rs
+++ b/src/unix/utf8.rs
@@ -84,6 +84,16 @@ where
     pub fn with_unix_encoding(&self) -> Utf8PathBuf<Utf8UnixEncoding> {
         self.with_encoding()
     }
+
+    /// Creates an owned [`Utf8PathBuf`] like `self` but using [`Utf8UnixEncoding`], ensuring it is
+    /// a valid Unix path.
+    ///
+    /// See [`Utf8Path::with_encoding_checked`] for more information.
+    pub fn with_unix_encoding_checked(
+        &self,
+    ) -> Result<Utf8PathBuf<Utf8UnixEncoding>, CheckedPathError> {
+        self.with_encoding_checked()
+    }
 }
 
 impl Utf8UnixPath {

--- a/src/unix/utf8.rs
+++ b/src/unix/utf8.rs
@@ -5,6 +5,7 @@ use core::hash::Hasher;
 
 pub use components::*;
 
+use crate::common::CheckedPathError;
 use crate::no_std_compat::*;
 use crate::typed::{Utf8TypedPath, Utf8TypedPathBuf};
 use crate::{private, Encoding, UnixEncoding, Utf8Encoding, Utf8Path, Utf8PathBuf};
@@ -40,6 +41,10 @@ impl<'a> Utf8Encoding<'a> for Utf8UnixEncoding {
         unsafe {
             UnixEncoding::push(current_path.as_mut_vec(), path.as_bytes());
         }
+    }
+
+    fn push_checked(current_path: &mut String, path: &str) -> Result<(), CheckedPathError> {
+        unsafe { UnixEncoding::push_checked(current_path.as_mut_vec(), path.as_bytes()) }
     }
 }
 
@@ -129,5 +134,115 @@ mod tests {
         let mut current_path = String::from("some/path/");
         Utf8UnixEncoding::push(&mut current_path, "abc");
         assert_eq!(current_path, "some/path/abc");
+    }
+
+    #[test]
+    fn push_checked_should_fail_if_providing_an_absolute_path() {
+        // Empty current path will fail when pushing an absolute path
+        let mut current_path = String::new();
+        assert_eq!(
+            Utf8UnixEncoding::push_checked(&mut current_path, "/abc"),
+            Err(CheckedPathError::UnexpectedRoot)
+        );
+        assert_eq!(current_path, "");
+
+        // Non-empty relative current path will fail when pushing an absolute path
+        let mut current_path = String::from("some/path");
+        assert_eq!(
+            Utf8UnixEncoding::push_checked(&mut current_path, "/abc"),
+            Err(CheckedPathError::UnexpectedRoot)
+        );
+        assert_eq!(current_path, "some/path");
+
+        // Non-empty absolute current path will fail when pushing an absolute path
+        let mut current_path = String::from("/some/path/");
+        assert_eq!(
+            Utf8UnixEncoding::push_checked(&mut current_path, "/abc"),
+            Err(CheckedPathError::UnexpectedRoot)
+        );
+        assert_eq!(current_path, "/some/path/");
+    }
+
+    #[test]
+    fn push_checked_should_fail_if_providing_a_path_with_disallowed_filename_characters() {
+        // Empty current path will fail when pushing a path containing disallowed filename chars
+        let mut current_path = String::new();
+        assert_eq!(
+            Utf8UnixEncoding::push_checked(&mut current_path, "some/inva\0lid/path"),
+            Err(CheckedPathError::InvalidFilename)
+        );
+        assert_eq!(current_path, "");
+
+        // Non-empty relative current path will fail when pushing a path containing disallowed
+        // filename bytes
+        let mut current_path = String::from("some/path");
+        assert_eq!(
+            Utf8UnixEncoding::push_checked(&mut current_path, "some/inva\0lid/path"),
+            Err(CheckedPathError::InvalidFilename)
+        );
+        assert_eq!(current_path, "some/path");
+
+        // Non-empty absolute current path will fail when pushing a path containing disallowed
+        // filename bytes
+        let mut current_path = String::from("/some/path/");
+        assert_eq!(
+            Utf8UnixEncoding::push_checked(&mut current_path, "some/inva\0lid/path"),
+            Err(CheckedPathError::InvalidFilename)
+        );
+        assert_eq!(current_path, "/some/path/");
+    }
+
+    #[test]
+    fn push_checked_should_fail_if_providing_a_path_that_would_escape_the_current_path() {
+        // Empty current path will fail when pushing a path that would escape
+        let mut current_path = String::new();
+        assert_eq!(
+            Utf8UnixEncoding::push_checked(&mut current_path, ".."),
+            Err(CheckedPathError::PathTraversalAttack)
+        );
+        assert_eq!(current_path, "");
+
+        // Non-empty relative current path will fail when pushing a path that would escape
+        let mut current_path = String::from("some/path");
+        assert_eq!(
+            Utf8UnixEncoding::push_checked(&mut current_path, ".."),
+            Err(CheckedPathError::PathTraversalAttack)
+        );
+        assert_eq!(current_path, "some/path");
+
+        // Non-empty absolute current path will fail when pushing a path that would escape
+        let mut current_path = String::from("/some/path/");
+        assert_eq!(
+            Utf8UnixEncoding::push_checked(&mut current_path, ".."),
+            Err(CheckedPathError::PathTraversalAttack)
+        );
+        assert_eq!(current_path, "/some/path/");
+    }
+
+    #[test]
+    fn push_checked_should_append_path_to_current_path_with_a_separator_if_does_not_violate_rules()
+    {
+        // Pushing a path that contains parent dirs, but does not escape the current path,
+        // should succeed
+        let mut current_path = String::new();
+        assert_eq!(
+            Utf8UnixEncoding::push_checked(&mut current_path, "abc/../def/."),
+            Ok(()),
+        );
+        assert_eq!(current_path, "abc/../def/.");
+
+        let mut current_path = String::from("some/path");
+        assert_eq!(
+            Utf8UnixEncoding::push_checked(&mut current_path, "abc/../def/."),
+            Ok(()),
+        );
+        assert_eq!(current_path, "some/path/abc/../def/.");
+
+        let mut current_path = String::from("/some/path/");
+        assert_eq!(
+            Utf8UnixEncoding::push_checked(&mut current_path, "abc/../def/."),
+            Ok(()),
+        );
+        assert_eq!(current_path, "/some/path/abc/../def/.");
     }
 }

--- a/src/windows/non_utf8.rs
+++ b/src/windows/non_utf8.rs
@@ -261,6 +261,16 @@ where
     pub fn with_windows_encoding(&self) -> PathBuf<WindowsEncoding> {
         self.with_encoding()
     }
+
+    /// Creates an owned [`PathBuf`] like `self` but using [`WindowsEncoding`], ensuring it is a
+    /// valid Windows path.
+    ///
+    /// See [`Path::with_encoding_checked`] for more information.
+    pub fn with_windows_encoding_checked(
+        &self,
+    ) -> Result<PathBuf<WindowsEncoding>, CheckedPathError> {
+        self.with_encoding_checked()
+    }
 }
 
 impl WindowsPath {

--- a/src/windows/utf8.rs
+++ b/src/windows/utf8.rs
@@ -5,6 +5,7 @@ use core::hash::Hasher;
 
 pub use components::*;
 
+use crate::common::CheckedPathError;
 use crate::no_std_compat::*;
 use crate::typed::{Utf8TypedPath, Utf8TypedPathBuf};
 use crate::{private, Encoding, Utf8Encoding, Utf8Path, Utf8PathBuf, WindowsEncoding};
@@ -40,6 +41,10 @@ impl<'a> Utf8Encoding<'a> for Utf8WindowsEncoding {
         unsafe {
             WindowsEncoding::push(current_path.as_mut_vec(), path.as_bytes());
         }
+    }
+
+    fn push_checked(current_path: &mut String, path: &str) -> Result<(), CheckedPathError> {
+        unsafe { WindowsEncoding::push_checked(current_path.as_mut_vec(), path.as_bytes()) }
     }
 }
 
@@ -88,5 +93,147 @@ impl Utf8WindowsPath {
 
     pub fn to_typed_path_buf(&self) -> Utf8TypedPathBuf {
         Utf8TypedPathBuf::from_windows(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_checked_should_fail_if_providing_an_absolute_path() {
+        // Empty current path will fail when pushing an absolute path
+        let mut current_path = String::new();
+        assert_eq!(
+            Utf8WindowsEncoding::push_checked(&mut current_path, r"\abc"),
+            Err(CheckedPathError::UnexpectedRoot)
+        );
+        assert_eq!(current_path, "");
+
+        // Non-empty relative current path will fail when pushing an absolute path
+        let mut current_path = String::from(r"some\path");
+        assert_eq!(
+            Utf8WindowsEncoding::push_checked(&mut current_path, r"\abc"),
+            Err(CheckedPathError::UnexpectedRoot)
+        );
+        assert_eq!(current_path, r"some\path");
+
+        // Non-empty absolute current path will fail when pushing an absolute path
+        let mut current_path = String::from(r"\some\path\");
+        assert_eq!(
+            Utf8WindowsEncoding::push_checked(&mut current_path, r"\abc"),
+            Err(CheckedPathError::UnexpectedRoot)
+        );
+        assert_eq!(current_path, r"\some\path\");
+    }
+
+    #[test]
+    fn push_checked_should_fail_if_providing_a_path_with_an_embedded_prefix() {
+        // Empty current path will fail when pushing a path with a prefix
+        let mut current_path = String::new();
+        assert_eq!(
+            Utf8WindowsEncoding::push_checked(&mut current_path, r"C:abc"),
+            Err(CheckedPathError::UnexpectedPrefix)
+        );
+        assert_eq!(current_path, "");
+
+        // Non-empty relative current path will fail when pushing a path with a prefix
+        let mut current_path = String::from(r"some\path");
+        assert_eq!(
+            Utf8WindowsEncoding::push_checked(&mut current_path, r"C:abc"),
+            Err(CheckedPathError::UnexpectedPrefix)
+        );
+        assert_eq!(current_path, r"some\path");
+
+        // Non-empty absolute current path will fail when pushing a path with a prefix
+        let mut current_path = String::from(r"\some\path\");
+        assert_eq!(
+            Utf8WindowsEncoding::push_checked(&mut current_path, r"C:abc"),
+            Err(CheckedPathError::UnexpectedPrefix)
+        );
+        assert_eq!(current_path, r"\some\path\");
+    }
+
+    #[test]
+    fn push_checked_should_fail_if_providing_a_path_with_disallowed_filename_bytes() {
+        // Empty current path will fail when pushing a path containing disallowed filename bytes
+        let mut current_path = String::new();
+        assert_eq!(
+            Utf8WindowsEncoding::push_checked(&mut current_path, r"some\inva|lid\path"),
+            Err(CheckedPathError::InvalidFilename)
+        );
+        assert_eq!(current_path, "");
+
+        // Non-empty relative current path will fail when pushing a path containing disallowed
+        // filename bytes
+        let mut current_path = String::from(r"some\path");
+        assert_eq!(
+            Utf8WindowsEncoding::push_checked(&mut current_path, r"some\inva|lid\path"),
+            Err(CheckedPathError::InvalidFilename)
+        );
+        assert_eq!(current_path, r"some\path");
+
+        // Non-empty absolute current path will fail when pushing a path containing disallowed
+        // filename bytes
+        let mut current_path = String::from(r"\some\path\");
+        assert_eq!(
+            Utf8WindowsEncoding::push_checked(&mut current_path, r"some\inva|lid\path"),
+            Err(CheckedPathError::InvalidFilename)
+        );
+        assert_eq!(current_path, r"\some\path\");
+    }
+
+    #[test]
+    fn push_checked_should_fail_if_providing_a_path_that_would_escape_the_current_path() {
+        // Empty current path will fail when pushing a path that would escape
+        let mut current_path = String::new();
+        assert_eq!(
+            Utf8WindowsEncoding::push_checked(&mut current_path, ".."),
+            Err(CheckedPathError::PathTraversalAttack)
+        );
+        assert_eq!(current_path, "");
+
+        // Non-empty relative current path will fail when pushing a path that would escape
+        let mut current_path = String::from(r"some\path");
+        assert_eq!(
+            Utf8WindowsEncoding::push_checked(&mut current_path, ".."),
+            Err(CheckedPathError::PathTraversalAttack)
+        );
+        assert_eq!(current_path, r"some\path");
+
+        // Non-empty absolute current path will fail when pushing a path that would escape
+        let mut current_path = String::from(r"\some\path\");
+        assert_eq!(
+            Utf8WindowsEncoding::push_checked(&mut current_path, ".."),
+            Err(CheckedPathError::PathTraversalAttack)
+        );
+        assert_eq!(current_path, r"\some\path\");
+    }
+
+    #[test]
+    fn push_checked_should_append_path_to_current_path_with_a_separator_if_does_not_violate_rules()
+    {
+        // Pushing a path that contains parent dirs, but does not escape the current path,
+        // should succeed
+        let mut current_path = String::new();
+        assert_eq!(
+            Utf8WindowsEncoding::push_checked(&mut current_path, r"abc\..\def\."),
+            Ok(()),
+        );
+        assert_eq!(current_path, r"abc\..\def\.");
+
+        let mut current_path = String::from(r"some\path");
+        assert_eq!(
+            Utf8WindowsEncoding::push_checked(&mut current_path, r"abc\..\def\."),
+            Ok(()),
+        );
+        assert_eq!(current_path, r"some\path\abc\..\def\.");
+
+        let mut current_path = String::from(r"\some\path\");
+        assert_eq!(
+            Utf8WindowsEncoding::push_checked(&mut current_path, r"abc\..\def\."),
+            Ok(()),
+        );
+        assert_eq!(current_path, r"\some\path\abc\..\def\.");
     }
 }

--- a/src/windows/utf8.rs
+++ b/src/windows/utf8.rs
@@ -84,6 +84,16 @@ where
     pub fn with_windows_encoding(&self) -> Utf8PathBuf<Utf8WindowsEncoding> {
         self.with_encoding()
     }
+
+    /// Creates an owned [`Utf8PathBuf`] like `self` but using [`Utf8WindowsEncoding`], ensuring it
+    /// is a valid Windows path.
+    ///
+    /// See [`Utf8Path::with_encoding_checked`] for more information.
+    pub fn with_windows_encoding_checked(
+        &self,
+    ) -> Result<Utf8PathBuf<Utf8WindowsEncoding>, CheckedPathError> {
+        self.with_encoding_checked()
+    }
 }
 
 impl Utf8WindowsPath {


### PR DESCRIPTION
Resolves #22 and #19.

### Checklist

- [x] push_checked
    - [x] `src/common/non_utf8.rs` trait def
    - [x] `src/common/utf8.rs` trait def
    - [x] `src/common/non_utf8/pathbuf.rs` fn impl
    - [x] `src/common/utf8/pathbuf.rs` fn impl
    - [x] `src/unix/non_utf8.rs` trait impl
    - [x] `src/unix/utf8.rs` trait impl
    - [x] `src/windows/non_utf8.rs` trait impl
    - [x] `src/windows/utf8.rs` trait impl
    - [x] `src/typed/non_utf8/pathbuf.rs` fn impl
    - [x] `src/typed/utf8/pathbuf.rs` fn impl
- [x] join_checked
    - [x] `src/common/non_utf8/path.rs` fn impl
    - [x] `src/common/utf8/path.rs` fn impl
    - [x] `src/typed/non_utf8/path.rs` fn impl
    - [x] `src/typed/utf8/path.rs` fn impl
    - [x] `src/typed/non_utf8/pathbuf.rs` fn impl
    - [x] `src/typed/utf8/pathbuf.rs` fn impl
- [x] with_encoding_checked
    - [x] `src/common/non_utf8/path.rs` fn impl
    - [x] `src/common/utf8/path.rs` fn impl
- [x] with_unix_encoding_checked
    - [x] `src/common/unix/non_utf8.rs` fn impl
    - [x] `src/common/unix/utf8.rs` fn impl
    - [x] `src/typed/non_utf8/path.rs` fn impl
    - [x] `src/typed/non_utf8/pathbuf.rs` fn impl
    - [x] `src/typed/utf8/path.rs` fn impl
    - [x] `src/typed/utf8/pathbuf.rs` fn impl
- [x] with_windows_encoding_checked
    - [x] `src/common/windows/non_utf8.rs` fn impl
    - [x] `src/common/windows/utf8.rs` fn impl
    - [x] `src/typed/non_utf8/path.rs` fn impl
    - [x] `src/typed/non_utf8/pathbuf.rs` fn impl
    - [x] `src/typed/utf8/path.rs` fn impl
    - [x] `src/typed/utf8/pathbuf.rs` fn impl