### PR TITLE
Add typed-path versions for `current_exe` and `temp_dir`, including UTF8 variants

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -69,7 +69,7 @@ pub fn utf8_current_dir() -> io::Result<Utf8NativePathBuf> {
 ///
 /// Returns an [`Err`] if unable to parse the path with the native encoding.
 ///
-/// Additionally, returns as [`Err`] if, as [`env::current_exe`] states,
+/// Additionally, returns a [`Err`] if, as [`env::current_exe`] states,
 /// a related filesystem operation or syscall fails.
 ///
 ///
@@ -98,7 +98,7 @@ pub fn current_exe() -> io::Result<NativePathBuf> {
 /// Returns an [`Err`] if unable to parse the path with the native encoding
 /// or the path was not valid UTF8.
 ///
-/// Additionally, returns as [`Err`] if, as [`env::current_exe`] states,
+/// Additionally, returns a [`Err`] if, as [`env::current_exe`] states,
 /// a related filesystem operation or syscall fails.
 ///
 ///

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -62,3 +62,111 @@ pub fn utf8_current_dir() -> io::Result<Utf8NativePathBuf> {
         Err(x) => Err(io::Error::new(io::ErrorKind::InvalidData, x)),
     }
 }
+
+/// Returns the full filesystem path of the current running executable as [`NativePathBuf`].
+///
+/// # Errors
+///
+/// Returns an [`Err`] if unable to parse the path with the native encoding.
+///
+/// Additionally, returns as [`Err`] if, as [`env::current_exe`] states,
+/// a related filesystem operation or syscall fails.
+///
+///
+/// # Examples
+///
+/// ```
+/// fn main() -> std::io::Result<()> {
+///     let path = typed_path::utils::current_exe()?;
+///     println!("The current executable path is {}", path.display());
+///     Ok(())
+/// }
+/// ```
+pub fn current_exe() -> io::Result<NativePathBuf> {
+    let std_current_exe = env::current_exe()?;
+
+    match NativePathBuf::try_from(std_current_exe) {
+        Ok(path) => Ok(path),
+        Err(_) => Err(io::Error::new(io::ErrorKind::InvalidData, "wrong encoding")),
+    }
+}
+
+/// Returns the full filesystem path of the current running executable as [`Utf8NativePathBuf`].
+///
+/// # Errors
+///
+/// Returns an [`Err`] if unable to parse the path with the native encoding
+/// or the path was not valid UTF8.
+///
+/// Additionally, returns as [`Err`] if, as [`env::current_exe`] states,
+/// a related filesystem operation or syscall fails.
+///
+///
+/// # Examples
+///
+/// ```
+/// fn main() -> std::io::Result<()> {
+///     let path = typed_path::utils::utf8_current_exe()?;
+///     println!("The current executable path is {}", path);
+///     Ok(())
+/// }
+/// ```
+pub fn utf8_current_exe() -> io::Result<Utf8NativePathBuf> {
+    let typed_current_exe = current_exe()?;
+
+    match Utf8NativePathBuf::from_bytes_path_buf(typed_current_exe) {
+        Ok(path) => Ok(path),
+        Err(error) => Err(io::Error::new(io::ErrorKind::InvalidData, error)),
+    }
+}
+
+/// Returns the path of a temporary directory as [`NativePathBuf`].
+///
+/// # Errors
+///
+/// Returns an [`Err`] if unable to parse the path with the native encoding.
+///
+///
+/// # Examples
+///
+/// ```
+/// fn main() -> std::io::Result<()> {
+///     let path = typed_path::utils::temp_dir()?;
+///     println!("The temporary directory path is {}", path.display());
+///     Ok(())
+/// }
+/// ```
+pub fn temp_dir() -> io::Result<NativePathBuf> {
+    let std_temp_dir = env::temp_dir();
+
+    match NativePathBuf::try_from(std_temp_dir) {
+        Ok(path) => Ok(path),
+        Err(_) => Err(io::Error::new(io::ErrorKind::InvalidData, "wrong encoding")),
+    }
+}
+
+/// Returns the path of a temporary directory as [`Utf8NativePathBuf`].
+///
+/// # Errors
+///
+/// Returns an [`Err`] if unable to parse the path with the native encoding
+/// or the path was not valid UTF8.
+///
+///
+/// # Examples
+///
+/// ```
+/// fn main() -> std::io::Result<()> {
+///     let path = typed_path::utils::utf8_temp_dir()?;
+///     println!("The temporary directory path is {}", path);
+///     Ok(())
+/// }
+/// ```
+pub fn utf8_temp_dir() -> io::Result<Utf8NativePathBuf> {
+    let typed_temp_dir = temp_dir()?;
+
+    match Utf8NativePathBuf::from_bytes_path_buf(typed_temp_dir) {
+        Ok(path) => Ok(path),
+        Err(error) => Err(io::Error::new(io::ErrorKind::InvalidData, error)),
+    }
+}


### PR DESCRIPTION
Hello! I'm currently migrating to `typed-path` in my project and noticed that there were two path-related functions from `std::env` that I could not find in the utilities module. 

This pull request adds the following functions under `typed_path::utils`:
- `current_exe`, which corresponds to `std::env::current_exe`,
- `utf8_current_exe`, which is a UTF8 version of `current_exe`,
- `temp_dir`, which corresponds to `std::env::temp_dir`, and
- `utf8_temp_dir`, which is a UTF8 version of `temp_dir`.