### PR TITLE
Add clippy warnings and update some metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2] - 2024-09-15
+
+* Fix `windows()` function of `TypedPathBuf` and `Utf8TypedPathBuf` to properly
+  return an instance of `WindowsPathBuf` and `Utf8WindowsPathBuf` respectively.
+  Before this fix, the function instead returned a Unix path wrapper.
+  ([#30](https://github.com/chipsenkbeil/typed-path/pull/30))
+* Minimum Rust version of 1.58.1 is now explicitly set via `rust-version`.
+* Address a variety of internal clippy warnings.
+
 ## [0.9.1] - 2024-07-16
 
 * Add derived `Hash`, `PartialOrd`, and `Ord` implementations for `TypedPath` and `TypedPathBuf` enumerations.
@@ -128,7 +137,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial release of the library!
 
-[Unreleased]: https://github.com/chipsenkbeil/typed-path/compare/v0.9.1...HEAD
+[Unreleased]: https://github.com/chipsenkbeil/typed-path/compare/v0.9.2...HEAD
+[0.9.2]: https://github.com/chipsenkbeil/typed-path/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/chipsenkbeil/typed-path/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/chipsenkbeil/typed-path/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/chipsenkbeil/typed-path/compare/v0.7.1...v0.8.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "typed-path"
 description = "Provides typed variants of Path and PathBuf for Unix and Windows"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
+rust-version = "1.58.1"
 authors = ["Chip Senkbeil <chip@senkbeil.org>"]
 categories = ["development-tools", "filesystem", "os"]
 keywords = ["unicode", "utf8", "paths", "filesystem"]

--- a/src/common/non_utf8/path.rs
+++ b/src/common/non_utf8/path.rs
@@ -213,10 +213,10 @@ where
     /// the current directory.
     ///
     /// * On Unix ([`UnixPath`]]), a path is absolute if it starts with the root, so
-    /// `is_absolute` and [`has_root`] are equivalent.
+    ///   `is_absolute` and [`has_root`] are equivalent.
     ///
     /// * On Windows ([`WindowsPath`]), a path is absolute if it has a prefix and starts with the
-    /// root: `c:\windows` is absolute, while `c:temp` and `\temp` are not.
+    ///   root: `c:\windows` is absolute, while `c:temp` and `\temp` are not.
     ///
     /// [`UnixPath`]: crate::UnixPath
     /// [`WindowsPath`]: crate::WindowsPath

--- a/src/common/utf8/path.rs
+++ b/src/common/utf8/path.rs
@@ -163,10 +163,10 @@ where
     /// the current directory.
     ///
     /// * On Unix ([`Utf8UnixPath`]]), a path is absolute if it starts with the root, so
-    /// `is_absolute` and [`has_root`] are equivalent.
+    ///   `is_absolute` and [`has_root`] are equivalent.
     ///
     /// * On Windows ([`Utf8WindowsPath`]), a path is absolute if it has a prefix and starts with
-    /// the root: `c:\windows` is absolute, while `c:temp` and `\temp` are not.
+    ///   the root: `c:\windows` is absolute, while `c:temp` and `\temp` are not.
     ///
     /// [`Utf8UnixPath`]: crate::Utf8UnixPath
     /// [`Utf8WindowsPath`]: crate::Utf8WindowsPath
@@ -1434,7 +1434,7 @@ mod helpers {
             return (Some(file), None);
         }
 
-        let mut iter = file.rsplitn(2, |b: char| b == '.');
+        let mut iter = file.rsplitn(2, '.');
         let after = iter.next();
         let before = iter.next();
         if before == Some("") {

--- a/src/typed/non_utf8/path.rs
+++ b/src/typed/non_utf8/path.rs
@@ -152,10 +152,10 @@ impl<'a> TypedPath<'a> {
     /// the current directory.
     ///
     /// * On Unix ([`UnixPath`]]), a path is absolute if it starts with the root, so
-    /// `is_absolute` and [`has_root`] are equivalent.
+    ///   `is_absolute` and [`has_root`] are equivalent.
     ///
     /// * On Windows ([`WindowsPath`]), a path is absolute if it has a prefix and starts with the
-    /// root: `c:\windows` is absolute, while `c:temp` and `\temp` are not.
+    ///   root: `c:\windows` is absolute, while `c:temp` and `\temp` are not.
     ///
     /// [`UnixPath`]: crate::UnixPath
     /// [`WindowsPath`]: crate::WindowsPath

--- a/src/typed/non_utf8/pathbuf.rs
+++ b/src/typed/non_utf8/pathbuf.rs
@@ -466,10 +466,10 @@ impl TypedPathBuf {
     /// the current directory.
     ///
     /// * On Unix ([`UnixPathBuf`]]), a path is absolute if it starts with the root, so
-    /// `is_absolute` and [`has_root`] are equivalent.
+    ///   `is_absolute` and [`has_root`] are equivalent.
     ///
     /// * On Windows ([`WindowsPathBuf`]), a path is absolute if it has a prefix and starts with
-    /// the root: `c:\windows` is absolute, while `c:temp` and `\temp` are not.
+    ///   the root: `c:\windows` is absolute, while `c:temp` and `\temp` are not.
     ///
     /// [`UnixPathBuf`]: crate::UnixPathBuf
     /// [`WindowsPathBuf`]: crate::WindowsPathBuf

--- a/src/typed/utf8/path.rs
+++ b/src/typed/utf8/path.rs
@@ -105,10 +105,10 @@ impl<'a> Utf8TypedPath<'a> {
     /// the current directory.
     ///
     /// * On Unix ([`UnixPath`]]), a path is absolute if it starts with the root, so
-    /// `is_absolute` and [`has_root`] are equivalent.
+    ///   `is_absolute` and [`has_root`] are equivalent.
     ///
     /// * On Windows ([`WindowsPath`]), a path is absolute if it has a prefix and starts with the
-    /// root: `c:\windows` is absolute, while `c:temp` and `\temp` are not.
+    ///   root: `c:\windows` is absolute, while `c:temp` and `\temp` are not.
     ///
     /// [`UnixPath`]: crate::UnixPath
     /// [`WindowsPath`]: crate::WindowsPath

--- a/src/typed/utf8/pathbuf.rs
+++ b/src/typed/utf8/pathbuf.rs
@@ -424,10 +424,10 @@ impl Utf8TypedPathBuf {
     /// the current directory.
     ///
     /// * On Unix ([`Utf8UnixPathBuf`]]), a path is absolute if it starts with the root, so
-    /// `is_absolute` and [`has_root`] are equivalent.
+    ///   `is_absolute` and [`has_root`] are equivalent.
     ///
     /// * On Windows ([`Utf8WindowsPathBuf`]), a path is absolute if it has a prefix and starts with
-    /// the root: `c:\windows` is absolute, while `c:temp` and `\temp` are not.
+    ///   the root: `c:\windows` is absolute, while `c:temp` and `\temp` are not.
     ///
     /// [`Utf8UnixPathBuf`]: crate::Utf8UnixPathBuf
     /// [`Utf8WindowsPathBuf`]: crate::Utf8WindowsPathBuf

--- a/src/unix/non_utf8/components/parser.rs
+++ b/src/unix/non_utf8/components/parser.rs
@@ -711,7 +711,7 @@ mod tests {
             cur_dir(b"").unwrap_err();
 
             // Not starting with current dir fails
-            cur_dir(&[&[b'a'], CURRENT_DIR].concat()).unwrap_err();
+            cur_dir(&[b"a", CURRENT_DIR].concat()).unwrap_err();
 
             // Succeeds just on its own
             let (input, value) = cur_dir(CURRENT_DIR).unwrap();
@@ -720,8 +720,8 @@ mod tests {
 
             // Fails if more content after itself that is not a separator
             // E.g. .. will fail, .a will fail
-            cur_dir(&[CURRENT_DIR, &[b'.']].concat()).unwrap_err();
-            cur_dir(&[CURRENT_DIR, &[b'a']].concat()).unwrap_err();
+            cur_dir(&[CURRENT_DIR, b"."].concat()).unwrap_err();
+            cur_dir(&[CURRENT_DIR, b"a"].concat()).unwrap_err();
 
             // Succeeds, taking only what it matches
             let input = &[CURRENT_DIR, &sep(1), CURRENT_DIR].concat();
@@ -736,7 +736,7 @@ mod tests {
             parent_dir(b"").unwrap_err();
 
             // Not starting with parent dir fails
-            parent_dir(&[&[b'a'], PARENT_DIR].concat()).unwrap_err();
+            parent_dir(&[b"a", PARENT_DIR].concat()).unwrap_err();
 
             // Succeeds just on its own
             let (input, value) = parent_dir(PARENT_DIR).unwrap();
@@ -745,8 +745,8 @@ mod tests {
 
             // Fails if more content after itself that is not a separator
             // E.g. ... will fail, ..a will fail
-            parent_dir(&[PARENT_DIR, &[b'.']].concat()).unwrap_err();
-            parent_dir(&[PARENT_DIR, &[b'a']].concat()).unwrap_err();
+            parent_dir(&[PARENT_DIR, b"."].concat()).unwrap_err();
+            parent_dir(&[PARENT_DIR, b"a"].concat()).unwrap_err();
 
             // Succeeds, taking only what it matches
             let input = &[PARENT_DIR, &sep(1), PARENT_DIR].concat();

--- a/src/windows/constants.rs
+++ b/src/windows/constants.rs
@@ -38,6 +38,7 @@ pub const RESERVED_DEVICE_NAMES_STR: &[&str] = &[
 ];
 
 /// Bytes that are not allowed in file or directory names
+#[allow(clippy::byte_char_slices)]
 pub const DISALLOWED_FILENAME_BYTES: &[u8] =
     &[b'\\', b'/', b':', b'?', b'*', b'"', b'>', b'<', b'|', b'\0'];
 

--- a/src/windows/non_utf8/components/parser.rs
+++ b/src/windows/non_utf8/components/parser.rs
@@ -2070,7 +2070,7 @@ mod tests {
             cur_dir(b"").unwrap_err();
 
             // Not starting with current dir fails
-            cur_dir(&[&[b'a'], CURRENT_DIR].concat()).unwrap_err();
+            cur_dir(&[b"a", CURRENT_DIR].concat()).unwrap_err();
 
             // Succeeds just on its own
             let (input, value) = cur_dir(CURRENT_DIR).unwrap();
@@ -2079,8 +2079,8 @@ mod tests {
 
             // Fails if more content after itself that is not a separator
             // E.g. .. will fail, .a will fail
-            cur_dir(&[CURRENT_DIR, &[b'.']].concat()).unwrap_err();
-            cur_dir(&[CURRENT_DIR, &[b'a']].concat()).unwrap_err();
+            cur_dir(&[CURRENT_DIR, b"."].concat()).unwrap_err();
+            cur_dir(&[CURRENT_DIR, b"a"].concat()).unwrap_err();
 
             // Succeeds, taking up to primary separator
             let input = &[CURRENT_DIR, br"\", CURRENT_DIR].concat();
@@ -2103,7 +2103,7 @@ mod tests {
             cur_dir(b"").unwrap_err();
 
             // Not starting with current dir fails
-            cur_dir(&[&[b'a'], CURRENT_DIR].concat()).unwrap_err();
+            cur_dir(&[b"a", CURRENT_DIR].concat()).unwrap_err();
 
             // Succeeds just on its own
             let (input, value) = cur_dir(CURRENT_DIR).unwrap();
@@ -2112,11 +2112,11 @@ mod tests {
 
             // Fails if more content after itself that is not a separator
             // E.g. .. will fail, .a will fail
-            cur_dir(&[CURRENT_DIR, &[b'.']].concat()).unwrap_err();
-            cur_dir(&[CURRENT_DIR, &[b'a']].concat()).unwrap_err();
+            cur_dir(&[CURRENT_DIR, b"."].concat()).unwrap_err();
+            cur_dir(&[CURRENT_DIR, b"a"].concat()).unwrap_err();
 
             // Also fails with alternate separator
-            cur_dir(&[CURRENT_DIR, &[b'/']].concat()).unwrap_err();
+            cur_dir(&[CURRENT_DIR, b"/"].concat()).unwrap_err();
 
             // Succeeds, taking up to primary separator
             let input = &[CURRENT_DIR, br"\", CURRENT_DIR].concat();
@@ -2133,7 +2133,7 @@ mod tests {
             parent_dir(b"").unwrap_err();
 
             // Not starting with parent dir fails
-            parent_dir(&[&[b'a'], PARENT_DIR].concat()).unwrap_err();
+            parent_dir(&[b"a", PARENT_DIR].concat()).unwrap_err();
 
             // Succeeds just on its own
             let (input, value) = parent_dir(PARENT_DIR).unwrap();
@@ -2142,8 +2142,8 @@ mod tests {
 
             // Fails if more content after itself that is not a separator
             // E.g. ... will fail, ..a will fail
-            parent_dir(&[PARENT_DIR, &[b'.']].concat()).unwrap_err();
-            parent_dir(&[PARENT_DIR, &[b'a']].concat()).unwrap_err();
+            parent_dir(&[PARENT_DIR, b"."].concat()).unwrap_err();
+            parent_dir(&[PARENT_DIR, b"a"].concat()).unwrap_err();
 
             // Succeeds, taking up to primary separator
             let input = &[PARENT_DIR, br"\", PARENT_DIR].concat();
@@ -2166,7 +2166,7 @@ mod tests {
             parent_dir(b"").unwrap_err();
 
             // Not starting with parent dir fails
-            parent_dir(&[&[b'a'], PARENT_DIR].concat()).unwrap_err();
+            parent_dir(&[b"a", PARENT_DIR].concat()).unwrap_err();
 
             // Succeeds just on its own
             let (input, value) = parent_dir(PARENT_DIR).unwrap();
@@ -2175,11 +2175,11 @@ mod tests {
 
             // Fails if more content after itself that is not a separator
             // E.g. ... will fail, ..a will fail
-            parent_dir(&[PARENT_DIR, &[b'.']].concat()).unwrap_err();
-            parent_dir(&[PARENT_DIR, &[b'a']].concat()).unwrap_err();
+            parent_dir(&[PARENT_DIR, b"."].concat()).unwrap_err();
+            parent_dir(&[PARENT_DIR, b"a"].concat()).unwrap_err();
 
             // Also fails with alternate separator
-            parent_dir(&[PARENT_DIR, &[b'/']].concat()).unwrap_err();
+            parent_dir(&[PARENT_DIR, b"/"].concat()).unwrap_err();
 
             // Succeeds, taking up to primary separator
             let input = &[PARENT_DIR, br"\", PARENT_DIR].concat();


### PR DESCRIPTION
1. Address many new clippy warnings
2. Add rust-version to Cargo.toml to mark 1.58.1 as minimum
3. Bump crate version to 0.9.2