### PR TITLE
Add PlatformEncoding and Utf8PlatformEncoding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ mod common;
 mod convert;
 #[cfg(not(target_family = "wasm"))]
 mod native;
+#[cfg(not(target_family = "wasm"))]
+mod platform;
 mod typed;
 mod unix;
 #[cfg(all(feature = "std", not(target_family = "wasm")))]
@@ -37,6 +39,8 @@ pub use common::*;
 pub use convert::*;
 #[cfg(not(target_family = "wasm"))]
 pub use native::*;
+#[cfg(not(target_family = "wasm"))]
+pub use platform::*;
 pub use typed::*;
 pub use unix::*;
 pub use windows::*;

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,0 +1,334 @@
+pub use self::non_utf8::*;
+pub use self::utf8::*;
+
+mod non_utf8 {
+    use crate::common::{CheckedPathError, Encoding, Path, PathBuf};
+    use crate::native::NativeEncoding;
+    use crate::no_std_compat::*;
+    use crate::private;
+    use core::any::TypeId;
+    use core::fmt;
+    use core::hash::Hasher;
+
+    /// [`Path`] that has the platform's encoding during compilation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::PlatformPath;
+    ///
+    /// // You can create the path like normal, but it is a distinct encoding from Unix/Windows
+    /// let path = PlatformPath::new("some/path");
+    ///
+    /// // The path will still behave like normal and even report its underlying encoding
+    /// assert_eq!(path.has_unix_encoding(), cfg!(unix));
+    /// assert_eq!(path.has_windows_encoding(), cfg!(windows));
+    ///
+    /// // It can still be converted into specific platform paths
+    /// let unix_path = path.with_unix_encoding();
+    /// let win_path = path.with_windows_encoding();
+    /// ```
+    pub type PlatformPath = Path<PlatformEncoding>;
+
+    /// [`PathBuf`] that has the platform's encoding during compilation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::PlatformPathBuf;
+    ///
+    /// // You can create the pathbuf like normal, but it is a distinct encoding from Unix/Windows
+    /// let path = PlatformPathBuf::from("some/path");
+    ///
+    /// // The path will still behave like normal and even report its underlying encoding
+    /// assert_eq!(path.has_unix_encoding(), cfg!(unix));
+    /// assert_eq!(path.has_windows_encoding(), cfg!(windows));
+    ///
+    /// // It can still be converted into specific platform paths
+    /// let unix_path = path.with_unix_encoding();
+    /// let win_path = path.with_windows_encoding();
+    /// ```
+    pub type PlatformPathBuf = PathBuf<PlatformEncoding>;
+
+    /// Represents an abstraction of [`Encoding`] that represents the current platform encoding.
+    ///
+    /// This differs from [`NativeEncoding`] in that it is its own struct instead of a type alias
+    /// to the platform-specific encoding, and can therefore be used to enforce more strict
+    /// compile-time checks of encodings without needing to leverage conditional configs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use core::any::TypeId;
+    /// use typed_path::{PlatformEncoding, UnixEncoding, WindowsEncoding};
+    ///
+    /// // The platform encoding is considered a distinct type from Unix/Windows encodings.
+    /// assert_ne!(TypeId::of::<PlatformEncoding>(), TypeId::of::<UnixEncoding>());
+    /// assert_ne!(TypeId::of::<PlatformEncoding>(), TypeId::of::<WindowsEncoding>());
+    /// ```
+    #[derive(Copy, Clone)]
+    pub struct PlatformEncoding;
+
+    impl private::Sealed for PlatformEncoding {}
+
+    impl<'a> Encoding<'a> for PlatformEncoding {
+        type Components = <NativeEncoding as Encoding<'a>>::Components;
+
+        fn label() -> &'static str {
+            NativeEncoding::label()
+        }
+
+        fn components(path: &'a [u8]) -> Self::Components {
+            <NativeEncoding as Encoding<'a>>::components(path)
+        }
+
+        fn hash<H: Hasher>(path: &[u8], h: &mut H) {
+            <NativeEncoding as Encoding<'a>>::hash(path, h)
+        }
+
+        fn push(current_path: &mut Vec<u8>, path: &[u8]) {
+            <NativeEncoding as Encoding<'a>>::push(current_path, path);
+        }
+
+        fn push_checked(current_path: &mut Vec<u8>, path: &[u8]) -> Result<(), CheckedPathError> {
+            <NativeEncoding as Encoding<'a>>::push_checked(current_path, path)
+        }
+    }
+
+    impl fmt::Debug for PlatformEncoding {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("PlatformEncoding").finish()
+        }
+    }
+
+    impl fmt::Display for PlatformEncoding {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "PlatformEncoding")
+        }
+    }
+
+    impl<T> Path<T>
+    where
+        T: for<'enc> Encoding<'enc> + 'static,
+    {
+        /// Returns true if the encoding is the platform abstraction ([`PlatformEncoding`]),
+        /// otherwise returns false.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use typed_path::{PlatformPath, UnixPath, WindowsPath};
+        ///
+        /// assert!(PlatformPath::new("/some/path").has_platform_encoding());
+        /// assert!(!UnixPath::new("/some/path").has_platform_encoding());
+        /// assert!(!WindowsPath::new("/some/path").has_platform_encoding());
+        /// ```
+        pub fn has_platform_encoding(&self) -> bool {
+            TypeId::of::<T>() == TypeId::of::<PlatformEncoding>()
+        }
+    }
+}
+
+mod utf8 {
+    use crate::common::{CheckedPathError, Utf8Encoding, Utf8Path, Utf8PathBuf};
+    use crate::native::Utf8NativeEncoding;
+    use crate::no_std_compat::*;
+    use crate::private;
+    use core::any::TypeId;
+    use core::fmt;
+    use core::hash::Hasher;
+
+    #[cfg(feature = "std")]
+    use std::path::{Path as StdPath, PathBuf as StdPathBuf};
+
+    /// [`Utf8Path`] that has the platform's encoding during compilation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::Utf8PlatformPath;
+    ///
+    /// // You can create the path like normal, but it is a distinct encoding from Unix/Windows
+    /// let path = Utf8PlatformPath::new("some/path");
+    ///
+    /// // The path will still behave like normal and even report its underlying encoding
+    /// assert_eq!(path.has_unix_encoding(), cfg!(unix));
+    /// assert_eq!(path.has_windows_encoding(), cfg!(windows));
+    ///
+    /// // It can still be converted into specific platform paths
+    /// let unix_path = path.with_unix_encoding();
+    /// let win_path = path.with_windows_encoding();
+    /// ```
+    pub type Utf8PlatformPath = Utf8Path<Utf8PlatformEncoding>;
+
+    /// [`Utf8PathBuf`] that has the platform's encoding during compilation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_path::Utf8PlatformPathBuf;
+    ///
+    /// // You can create the pathbuf like normal, but it is a distinct encoding from Unix/Windows
+    /// let path = Utf8PlatformPathBuf::from("some/path");
+    ///
+    /// // The path will still behave like normal and even report its underlying encoding
+    /// assert_eq!(path.has_unix_encoding(), cfg!(unix));
+    /// assert_eq!(path.has_windows_encoding(), cfg!(windows));
+    ///
+    /// // It can still be converted into specific platform paths
+    /// let unix_path = path.with_unix_encoding();
+    /// let win_path = path.with_windows_encoding();
+    /// ```
+    pub type Utf8PlatformPathBuf = Utf8PathBuf<Utf8PlatformEncoding>;
+
+    /// Represents an abstraction of [`Utf8Encoding`] that represents the current platform
+    /// encoding.
+    ///
+    /// This differs from [`Utf8NativeEncoding`] in that it is its own struct instead of a type
+    /// alias to the platform-specific encoding, and can therefore be used to enforce more strict
+    /// compile-time checks of encodings without needing to leverage conditional configs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use core::any::TypeId;
+    /// use typed_path::{Utf8PlatformEncoding, Utf8UnixEncoding, Utf8WindowsEncoding};
+    ///
+    /// // The UTF8 platform encoding is considered a distinct type from UTF8 Unix/Windows encodings.
+    /// assert_ne!(TypeId::of::<Utf8PlatformEncoding>(), TypeId::of::<Utf8UnixEncoding>());
+    /// assert_ne!(TypeId::of::<Utf8PlatformEncoding>(), TypeId::of::<Utf8WindowsEncoding>());
+    /// ```
+    #[derive(Copy, Clone)]
+    pub struct Utf8PlatformEncoding;
+
+    impl private::Sealed for Utf8PlatformEncoding {}
+
+    impl<'a> Utf8Encoding<'a> for Utf8PlatformEncoding {
+        type Components = <Utf8NativeEncoding as Utf8Encoding<'a>>::Components;
+
+        fn label() -> &'static str {
+            Utf8NativeEncoding::label()
+        }
+
+        fn components(path: &'a str) -> Self::Components {
+            <Utf8NativeEncoding as Utf8Encoding<'a>>::components(path)
+        }
+
+        fn hash<H: Hasher>(path: &str, h: &mut H) {
+            <Utf8NativeEncoding as Utf8Encoding<'a>>::hash(path, h)
+        }
+
+        fn push(current_path: &mut String, path: &str) {
+            <Utf8NativeEncoding as Utf8Encoding<'a>>::push(current_path, path);
+        }
+
+        fn push_checked(current_path: &mut String, path: &str) -> Result<(), CheckedPathError> {
+            <Utf8NativeEncoding as Utf8Encoding<'a>>::push_checked(current_path, path)
+        }
+    }
+
+    impl fmt::Debug for Utf8PlatformEncoding {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("Utf8PlatformEncoding").finish()
+        }
+    }
+
+    impl fmt::Display for Utf8PlatformEncoding {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "Utf8PlatformEncoding")
+        }
+    }
+
+    impl<T> Utf8Path<T>
+    where
+        T: for<'enc> Utf8Encoding<'enc> + 'static,
+    {
+        /// Returns true if the encoding is the platform abstraction ([`Utf8PlatformEncoding`]),
+        /// otherwise returns false.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use typed_path::{Utf8PlatformPath, Utf8UnixPath, Utf8WindowsPath};
+        ///
+        /// assert!(Utf8PlatformPath::new("/some/path").has_platform_encoding());
+        /// assert!(!Utf8UnixPath::new("/some/path").has_platform_encoding());
+        /// assert!(!Utf8WindowsPath::new("/some/path").has_platform_encoding());
+        /// ```
+        pub fn has_platform_encoding(&self) -> bool {
+            TypeId::of::<T>() == TypeId::of::<Utf8PlatformEncoding>()
+        }
+    }
+
+    #[cfg(all(feature = "std", not(target_family = "wasm")))]
+    impl AsRef<StdPath> for Utf8PlatformPath {
+        /// Converts a platform utf8 path (based on compilation family) into [`std::path::Path`].
+        ///
+        /// ```
+        /// use typed_path::Utf8PlatformPath;
+        /// use std::path::Path;
+        ///
+        /// let platform_path = Utf8PlatformPath::new("some_file.txt");
+        /// let std_path: &Path = platform_path.as_ref();
+        ///
+        /// assert_eq!(std_path, Path::new("some_file.txt"));
+        /// ```
+        fn as_ref(&self) -> &StdPath {
+            StdPath::new(self.as_str())
+        }
+    }
+
+    #[cfg(all(feature = "std", not(target_family = "wasm")))]
+    impl AsRef<StdPath> for Utf8PlatformPathBuf {
+        /// Converts a platform utf8 pathbuf (based on compilation family) into [`std::path::Path`].
+        ///
+        /// ```
+        /// use typed_path::Utf8PlatformPathBuf;
+        /// use std::path::Path;
+        ///
+        /// let platform_path_buf = Utf8PlatformPathBuf::from("some_file.txt");
+        /// let std_path: &Path = platform_path_buf.as_ref();
+        ///
+        /// assert_eq!(std_path, Path::new("some_file.txt"));
+        /// ```
+        fn as_ref(&self) -> &StdPath {
+            StdPath::new(self.as_str())
+        }
+    }
+
+    #[cfg(all(feature = "std", not(target_family = "wasm")))]
+    impl<'a> From<&'a Utf8PlatformPath> for StdPathBuf {
+        /// Converts a platform utf8 path (based on compilation family) into [`std::path::PathBuf`].
+        ///
+        /// ```
+        /// use typed_path::Utf8PlatformPath;
+        /// use std::path::PathBuf;
+        ///
+        /// let platform_path = Utf8PlatformPath::new("some_file.txt");
+        /// let std_path_buf = PathBuf::from(platform_path);
+        ///
+        /// assert_eq!(std_path_buf, PathBuf::from("some_file.txt"));
+        /// ```
+        fn from(utf8_platform_path: &'a Utf8PlatformPath) -> StdPathBuf {
+            StdPathBuf::from(utf8_platform_path.to_string())
+        }
+    }
+
+    #[cfg(all(feature = "std", not(target_family = "wasm")))]
+    impl From<Utf8PlatformPathBuf> for StdPathBuf {
+        /// Converts a platform utf8 pathbuf (based on compilation family) into [`std::path::PathBuf`].
+        ///
+        /// ```
+        /// use typed_path::Utf8PlatformPathBuf;
+        /// use std::path::PathBuf;
+        ///
+        /// let platform_path_buf = Utf8PlatformPathBuf::from("some_file.txt");
+        /// let std_path_buf = PathBuf::from(platform_path_buf);
+        ///
+        /// assert_eq!(std_path_buf, PathBuf::from("some_file.txt"));
+        /// ```
+        fn from(utf8_platform_path_buf: Utf8PlatformPathBuf) -> StdPathBuf {
+            StdPathBuf::from(utf8_platform_path_buf.into_string())
+        }
+    }
+}


### PR DESCRIPTION

Adds new `PlatformEncoding` and `Utf8PlatformEncoding` structs that implement the same logic as `NativeEncoding` and `Utf8NativeEncoding` but are structs instead of type aliases.

This enables stronger type enforcement without the need for conditional config as `PlatformEncoding` is not the same as `UnixEncoding` or `WindowsEncoding`, regardless of how it is implemented at compile-time.

### Tests

Run `cargo test platform --doc`.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/chipsenkbeil/typed-path/pull/34).
* #35
* __->__ #34