### PR TITLE
Add `with_platform_encoding` and `with_platform_encoding_checked` methods to `Path` and `Utf8Path`

### DIFF
--- a/src/platform.rs
+++ b/src/platform.rs
@@ -126,6 +126,23 @@ mod non_utf8 {
         pub fn has_platform_encoding(&self) -> bool {
             TypeId::of::<T>() == TypeId::of::<PlatformEncoding>()
         }
+
+        /// Creates an owned [`PathBuf`] like `self` but using [`PlatformEncoding`].
+        ///
+        /// See [`Path::with_encoding`] for more information.
+        pub fn with_platform_encoding(&self) -> PathBuf<PlatformEncoding> {
+            self.with_encoding()
+        }
+
+        /// Creates an owned [`PathBuf`] like `self` but using [`PlatformEncoding`], ensuring it is
+        /// a valid platform path.
+        ///
+        /// See [`Path::with_encoding_checked`] for more information.
+        pub fn with_platform_encoding_checked(
+            &self,
+        ) -> Result<PathBuf<PlatformEncoding>, CheckedPathError> {
+            self.with_encoding_checked()
+        }
     }
 }
 
@@ -257,6 +274,23 @@ mod utf8 {
         /// ```
         pub fn has_platform_encoding(&self) -> bool {
             TypeId::of::<T>() == TypeId::of::<Utf8PlatformEncoding>()
+        }
+
+        /// Creates an owned [`Utf8PathBuf`] like `self` but using [`Utf8PlatformEncoding`].
+        ///
+        /// See [`Utf8Path::with_encoding`] for more information.
+        pub fn with_platform_encoding(&self) -> Utf8PathBuf<Utf8PlatformEncoding> {
+            self.with_encoding()
+        }
+
+        /// Creates an owned [`Utf8PathBuf`] like `self` but using [`Utf8PlatformEncoding`],
+        /// ensuring it is a valid platform path.
+        ///
+        /// See [`Utf8Path::with_encoding_checked`] for more information.
+        pub fn with_platform_encoding_checked(
+            &self,
+        ) -> Result<Utf8PathBuf<Utf8PlatformEncoding>, CheckedPathError> {
+            self.with_encoding_checked()
         }
     }
 


### PR DESCRIPTION

Adds with_platform_encoding` and `with_platform_encoding_checked` methods to `Path` and `Utf8Path` to support converting to the platform encoding in the same way as converting to unix and windows encodings specifically.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/chipsenkbeil/typed-path/pull/36).
* #35
* __->__ #36