### PR TITLE
Remove implementation of AsRef for utf8 native path and pathbuf

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -309,42 +309,6 @@ impl<'a> TryFrom<StdComponent<'a>> for WindowsComponent<'a> {
 }
 
 #[cfg(all(feature = "std", not(target_family = "wasm")))]
-impl AsRef<StdPath> for Utf8NativePath {
-    /// Converts a native utf8 path (based on compilation family) into [`std::path::Path`].
-    ///
-    /// ```
-    /// use typed_path::Utf8NativePath;
-    /// use std::path::Path;
-    ///
-    /// let native_path = Utf8NativePath::new("some_file.txt");
-    /// let std_path: &Path = native_path.as_ref();
-    ///
-    /// assert_eq!(std_path, Path::new("some_file.txt"));
-    /// ```
-    fn as_ref(&self) -> &StdPath {
-        StdPath::new(self.as_str())
-    }
-}
-
-#[cfg(all(feature = "std", not(target_family = "wasm")))]
-impl AsRef<StdPath> for Utf8NativePathBuf {
-    /// Converts a native utf8 pathbuf (based on compilation family) into [`std::path::Path`].
-    ///
-    /// ```
-    /// use typed_path::Utf8NativePathBuf;
-    /// use std::path::Path;
-    ///
-    /// let native_path_buf = Utf8NativePathBuf::from("some_file.txt");
-    /// let std_path: &Path = native_path_buf.as_ref();
-    ///
-    /// assert_eq!(std_path, Path::new("some_file.txt"));
-    /// ```
-    fn as_ref(&self) -> &StdPath {
-        StdPath::new(self.as_str())
-    }
-}
-
-#[cfg(all(feature = "std", not(target_family = "wasm")))]
 impl<'a> From<&'a Utf8NativePath> for StdPathBuf {
     /// Converts a native utf8 path (based on compilation family) into [`std::path::PathBuf`].
     ///


### PR DESCRIPTION

Removes the implementation of `AsRef<std::path::Path>` for both `Utf8NativePath` and `Utf8NativePathBuf` to avoid situations where code using native path aliases appears to compile on one platform and fails on another.

```rust
// Compiles on Unix-like platforms, does not compile on Windows
fn foo(path: &UnixPath) -> _ {
    std::fs::exists(path)
}
```

It is instead recommended to use the new `PlatformPath` to ensure types are respected and work across operating system targets.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/chipsenkbeil/typed-path/pull/38).
* #39
* __->__ #38