### PR TITLE
Expose native and platform modules only when unix or windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,9 @@ mod no_std_compat {
 
 #[macro_use]
 mod common;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), any(windows, unix)))]
 mod native;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), any(windows, unix)))]
 mod platform;
 mod typed;
 mod unix;
@@ -35,9 +35,9 @@ mod private {
 }
 
 pub use common::*;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), any(windows, unix)))]
 pub use native::*;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), any(windows, unix)))]
 pub use platform::*;
 pub use typed::*;
 pub use unix::*;


### PR DESCRIPTION
The `native` and `platform` modules assume that either windows or unix is a target. There are preexisting guards against exposing these modules when compiling with a wasm target, but there are other possible targets that are not either windows or unix (e.g. embedded targets). Currently, typed-path will not compile on these other targets.

This PR requires that either windows or unix be a target when exposing the `native` and `platform` modules.