### PR TITLE
Fix for platforms not supporting atomic loads

### DIFF
--- a/src/common/non_utf8/path.rs
+++ b/src/common/non_utf8/path.rs
@@ -2,6 +2,7 @@ mod display;
 
 use alloc::borrow::{Cow, ToOwned};
 use alloc::rc::Rc;
+#[cfg(target_has_atomic = "ptr")]
 use alloc::sync::Arc;
 use core::hash::{Hash, Hasher};
 use core::marker::PhantomData;
@@ -1259,6 +1260,7 @@ where
     }
 }
 
+#[cfg(target_has_atomic = "ptr")]
 impl<T> From<PathBuf<T>> for Arc<Path<T>>
 where
     T: Encoding,
@@ -1272,6 +1274,7 @@ where
     }
 }
 
+#[cfg(target_has_atomic = "ptr")]
 impl<T> From<&Path<T>> for Arc<Path<T>>
 where
     T: Encoding,

--- a/src/common/utf8/path.rs
+++ b/src/common/utf8/path.rs
@@ -1,5 +1,6 @@
 use alloc::borrow::{Cow, ToOwned};
 use alloc::rc::Rc;
+#[cfg(target_has_atomic = "ptr")]
 use alloc::sync::Arc;
 use core::hash::{Hash, Hasher};
 use core::marker::PhantomData;
@@ -1245,6 +1246,7 @@ where
     }
 }
 
+#[cfg(target_has_atomic = "ptr")]
 impl<T> From<Utf8PathBuf<T>> for Arc<Utf8Path<T>>
 where
     T: Utf8Encoding,
@@ -1258,6 +1260,7 @@ where
     }
 }
 
+#[cfg(target_has_atomic = "ptr")]
 impl<T> From<&Utf8Path<T>> for Arc<Utf8Path<T>>
 where
     T: Utf8Encoding,


### PR DESCRIPTION
The `alloc::sync` module is only available on platforms that support atomic loads and stores of pointers. This may be detected at compile time using `#[cfg(target_has_atomic = ptr)]`.

I encountered this issue when a user of a project of mine [detected](https://github.com/Oakchris1955/simple-fatfs/issues/16) that `typed-path` doesn't compile on `thumbv6m-none-eabi` targets.

P.S. Since this is essentially a patch fix and I'd like to be able to use this library on certain `thumbv6m-none-eabi` targets, is it possible to roll a patch version on crates.io? Thanks.