### PR TITLE
absolutize() should return error for ambiguous paths

### DIFF
--- a/src/common/non_utf8/path.rs
+++ b/src/common/non_utf8/path.rs
@@ -661,7 +661,8 @@ where
             let joined = cwd.join(self);
 
             if !joined.is_absolute() {
-                Err(std::io::Error::other(
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
                     "path cannot be absolutized without ambiguity",
                 ))
             } else {

--- a/src/common/non_utf8/path.rs
+++ b/src/common/non_utf8/path.rs
@@ -658,8 +658,15 @@ where
         } else {
             // Get the cwd as a platform path and convert to this path's encoding
             let cwd = crate::utils::current_dir()?.with_encoding();
+            let joined = cwd.join(self);
 
-            Ok(cwd.join(self).normalize())
+            if !joined.is_absolute() {
+                Err(std::io::Error::other(
+                    "path cannot be absolutized without ambiguity",
+                ))
+            } else {
+                Ok(joined.normalize())
+            }
         }
     }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -4,3 +4,31 @@ mod utf8;
 
 pub use non_utf8::*;
 pub use utf8::*;
+
+#[cfg(feature = "std")]
+#[test]
+fn absolutize_should_fail_for_windows_path_with_drive_letter_only_prefix() {
+    let p = WindowsPath::new(r"C:something");
+    assert!(p.absolutize().is_err())
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn absolutize_should_fail_for_windows_path_with_verbatim_drive_letter_only_prefix() {
+    let p = WindowsPath::new(r"\\?\C:something");
+    assert!(p.absolutize().is_err())
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn absolutize_should_fail_for_windows_path_with_unc_server_only_prefix() {
+    let p = WindowsPath::new(r"\\server");
+    assert!(p.absolutize().is_err())
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn absolutize_should_fail_for_windows_path_with_verbatim_unc_server_only_prefix() {
+    let p = WindowsPath::new(r"\\?\UNC\server");
+    assert!(p.absolutize().is_err())
+}


### PR DESCRIPTION
This addresses the "silent failure" piece of https://github.com/chipsenkbeil/typed-path/issues/61, and adds specific test cases:

- `C:something`: ambiguous because Windows maintains a per-disk cwd as a relic of MS-DOS, but only in certain contexts. (In others, this is treated as equivalent to `C:\something`.)
- `\\server`: this isn't a complete path. Without adding `\share` on the end, it can't be used in most contexts where Windows would allow a directory path; it should probably be `!is_valid()` as well as `!is_absolute()`.