### PR TITLE
Add serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,12 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+serde_core = { version = "1", features = ["alloc"], default-features = false, optional = true }
 
 [features]
 default = ["std"]
 std = []
+serde = ["dep:serde_core"]
 
 [[example]]
 name = "typed"
@@ -41,3 +43,6 @@ required-features = ["std"]
 [[example]]
 name = "windows_utf8"
 required-features = ["std"]
+
+[dev-dependencies]
+serde_json = "1"

--- a/src/common/non_utf8/parser.rs
+++ b/src/common/non_utf8/parser.rs
@@ -486,7 +486,7 @@ mod tests {
             fn should_succeed_if_child_parser_never_succeeds() {
                 let (input, value) = zero_or_more(byte(b'b'))(b"abc").unwrap();
                 assert_eq!(input, b"abc");
-                assert_eq!(value, Vec::new());
+                assert_eq!(value, Vec::<u8>::new());
             }
 
             #[test]

--- a/src/common/non_utf8/path.rs
+++ b/src/common/non_utf8/path.rs
@@ -9,6 +9,8 @@ use core::marker::PhantomData;
 use core::{cmp, fmt};
 
 pub use display::Display;
+#[cfg(feature = "serde")]
+use serde_core::{de, de::Visitor, ser::Error, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::common::{
     Ancestors, CheckedPathError, Component, Components, Encoding, Iter, PathBuf, StripPrefixError,
@@ -1485,6 +1487,79 @@ mod helpers {
             }
             iter = iter_next;
         }
+    }
+}
+
+#[cfg(feature = "serde")]
+struct PathVisitor<T>(PhantomData<T>)
+where
+    T: Encoding;
+
+#[cfg(feature = "serde")]
+impl<'a, T> Visitor<'a> for PathVisitor<T>
+where
+    T: Encoding + 'a,
+{
+    type Value = &'a Path<T>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a borrowed path")
+    }
+
+    fn visit_borrowed_str<E>(self, v: &'a str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Path::new(v))
+    }
+
+    fn visit_borrowed_bytes<E>(self, v: &'a [u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Path::new(v))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T> Serialize for Path<T>
+where
+    T: Encoding,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self.to_str() {
+            Some(s) => s.serialize(serializer),
+            None => Err(S::Error::custom("path contains invalid UTF-8 characters")),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de: 'a, 'a, T> Deserialize<'de> for &'a Path<T>
+where
+    T: Encoding + 'de,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(PathVisitor(PhantomData))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T> Deserialize<'de> for Box<Path<T>>
+where
+    T: Encoding,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Deserialize::deserialize(deserializer).map(PathBuf::into_boxed_path)
     }
 }
 

--- a/src/common/non_utf8/pathbuf.rs
+++ b/src/common/non_utf8/pathbuf.rs
@@ -784,7 +784,7 @@ where
     where
         E: de::Error,
     {
-        str::from_utf8(v)
+        core::str::from_utf8(v)
             .map(PathBuf::from)
             .map_err(|_| de::Error::invalid_value(Unexpected::Bytes(v), &self))
     }

--- a/src/common/non_utf8/pathbuf.rs
+++ b/src/common/non_utf8/pathbuf.rs
@@ -8,6 +8,13 @@ use core::ops::Deref;
 use core::str::FromStr;
 use core::{cmp, fmt};
 
+#[cfg(feature = "serde")]
+use serde_core::{
+    de,
+    de::{Unexpected, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+
 use crate::no_std_compat::*;
 use crate::{CheckedPathError, Encoding, Iter, Path};
 
@@ -740,6 +747,81 @@ where
             Some(s) => Ok(PathBuf::from(s)),
             None => Err(path),
         }
+    }
+}
+
+#[cfg(feature = "serde")]
+struct PathBufVisitor<T>(PhantomData<T>)
+where
+    T: Encoding;
+
+#[cfg(feature = "serde")]
+impl<'de, T> Visitor<'de> for PathBufVisitor<T>
+where
+    T: Encoding,
+{
+    type Value = PathBuf<T>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("path string")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(PathBuf::from(v))
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(PathBuf::from(v))
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        str::from_utf8(v)
+            .map(PathBuf::from)
+            .map_err(|_| de::Error::invalid_value(Unexpected::Bytes(v), &self))
+    }
+
+    fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        String::from_utf8(v)
+            .map(PathBuf::from)
+            .map_err(|e| de::Error::invalid_value(Unexpected::Bytes(&e.into_bytes()), &self))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T> Serialize for PathBuf<T>
+where
+    T: Encoding,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.as_path().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T> Deserialize<'de> for PathBuf<T>
+where
+    T: Encoding,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_string(PathBufVisitor(PhantomData))
     }
 }
 

--- a/src/common/utf8/path.rs
+++ b/src/common/utf8/path.rs
@@ -1500,7 +1500,7 @@ where
     where
         E: de::Error,
     {
-        str::from_utf8(v)
+        core::str::from_utf8(v)
             .map(str::as_ref)
             .map_err(|_| de::Error::invalid_value(Unexpected::Bytes(v), &self))
     }

--- a/src/common/utf8/path.rs
+++ b/src/common/utf8/path.rs
@@ -7,6 +7,13 @@ use core::marker::PhantomData;
 use core::str::Utf8Error;
 use core::{cmp, fmt};
 
+#[cfg(feature = "serde")]
+use serde_core::{
+    de,
+    de::{Unexpected, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+
 use crate::no_std_compat::*;
 use crate::{
     CheckedPathError, Encoding, Path, StripPrefixError, Utf8Ancestors, Utf8Component,
@@ -1466,6 +1473,78 @@ mod helpers {
     }
 }
 
+#[cfg(feature = "serde")]
+struct Utf8PathVisitor<T>(PhantomData<T>)
+where
+    T: Utf8Encoding;
+
+#[cfg(feature = "serde")]
+impl<'a, T> Visitor<'a> for Utf8PathVisitor<T>
+where
+    T: Utf8Encoding + 'a,
+{
+    type Value = &'a Utf8Path<T>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a borrowed UTF-8 path")
+    }
+
+    fn visit_borrowed_str<E>(self, v: &'a str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Utf8Path::new(v))
+    }
+
+    fn visit_borrowed_bytes<E>(self, v: &'a [u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        str::from_utf8(v)
+            .map(str::as_ref)
+            .map_err(|_| de::Error::invalid_value(Unexpected::Bytes(v), &self))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T> Serialize for Utf8Path<T>
+where
+    T: Utf8Encoding,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.as_str().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de: 'a, 'a, T> Deserialize<'de> for &'a Utf8Path<T>
+where
+    T: Utf8Encoding + 'de,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(Utf8PathVisitor(PhantomData))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T> Deserialize<'de> for Box<Utf8Path<T>>
+where
+    T: Utf8Encoding,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Deserialize::deserialize(deserializer).map(Utf8PathBuf::into_boxed_path)
+    }
+}
+
 #[cfg(any(
     unix,
     all(target_vendor = "fortanix", target_env = "sgx"),
@@ -1518,5 +1597,17 @@ mod std_conversions {
         fn as_ref(&self) -> &OsStr {
             OsStrExt::from_bytes(self.as_str().as_bytes())
         }
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests {
+    use crate::Utf8WindowsPath;
+
+    #[test]
+    fn deserialize_invalid_utf8() {
+        let bytes = vec![b'"', b'f', b'o', b'o', b'\\', 0xff, b'"'];
+
+        assert!(serde_json::from_slice::<&Utf8WindowsPath>(&bytes).is_err());
     }
 }

--- a/src/common/utf8/pathbuf.rs
+++ b/src/common/utf8/pathbuf.rs
@@ -9,6 +9,9 @@ use core::ops::Deref;
 use core::str::FromStr;
 use core::{cmp, fmt};
 
+#[cfg(feature = "serde")]
+use serde_core::{de, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+
 use crate::no_std_compat::*;
 use crate::{CheckedPathError, Encoding, PathBuf, Utf8Encoding, Utf8Iter, Utf8Path};
 
@@ -779,6 +782,81 @@ where
     }
 }
 
+#[cfg(feature = "serde")]
+struct Utf8PathBufVisitor<T>(PhantomData<T>)
+where
+    T: Utf8Encoding;
+
+#[cfg(feature = "serde")]
+impl<'de, T> Visitor<'de> for Utf8PathBufVisitor<T>
+where
+    T: Utf8Encoding,
+{
+    type Value = Utf8PathBuf<T>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("UTF-8 path string")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Utf8PathBuf::from(v))
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Utf8PathBuf::from(v))
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        str::from_utf8(v)
+            .map(Utf8PathBuf::from)
+            .map_err(|_| de::Error::invalid_value(de::Unexpected::Bytes(v), &self))
+    }
+
+    fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        String::from_utf8(v)
+            .map(Utf8PathBuf::from)
+            .map_err(|e| de::Error::invalid_value(de::Unexpected::Bytes(&e.into_bytes()), &self))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T> Serialize for Utf8PathBuf<T>
+where
+    T: Utf8Encoding,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.as_str().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T> Deserialize<'de> for Utf8PathBuf<T>
+where
+    T: Utf8Encoding,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_string(Utf8PathBufVisitor(PhantomData))
+    }
+}
+
 #[cfg(any(
     unix,
     all(target_vendor = "fortanix", target_env = "sgx"),
@@ -820,5 +898,17 @@ mod std_conversions {
         fn as_ref(&self) -> &OsStr {
             OsStrExt::from_bytes(self.as_str().as_bytes())
         }
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests {
+    use crate::Utf8WindowsPathBuf;
+
+    #[test]
+    fn deserialize_invalid_utf8() {
+        let bytes = vec![b'"', b'f', b'o', b'o', b'\\', 0xff, b'"'];
+
+        assert!(serde_json::from_slice::<Utf8WindowsPathBuf>(&bytes).is_err());
     }
 }

--- a/src/common/utf8/pathbuf.rs
+++ b/src/common/utf8/pathbuf.rs
@@ -816,7 +816,7 @@ where
     where
         E: de::Error,
     {
-        str::from_utf8(v)
+        core::str::from_utf8(v)
             .map(Utf8PathBuf::from)
             .map_err(|_| de::Error::invalid_value(de::Unexpected::Bytes(v), &self))
     }

--- a/src/typed/non_utf8/path.rs
+++ b/src/typed/non_utf8/path.rs
@@ -3,6 +3,9 @@ use core::fmt;
 #[cfg(all(feature = "std", not(target_family = "wasm")))]
 use std::io;
 
+#[cfg(feature = "serde")]
+use serde_core::{de, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+
 use crate::common::{CheckedPathError, StripPrefixError, TryAsRef};
 use crate::typed::{PathType, TypedAncestors, TypedComponents, TypedIter, TypedPathBuf};
 use crate::unix::UnixPath;
@@ -841,5 +844,95 @@ impl TryAsRef<WindowsPath> for TypedPath<'_> {
 impl PartialEq<TypedPathBuf> for TypedPath<'_> {
     fn eq(&self, path: &TypedPathBuf) -> bool {
         self.eq(&path.to_path())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for TypedPath<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Unix(unix_path) => unix_path.serialize(serializer),
+            Self::Windows(windows_path) => windows_path.serialize(serializer),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+struct TypedPathVisitor;
+
+#[cfg(feature = "serde")]
+impl<'de> Visitor<'de> for TypedPathVisitor {
+    type Value = TypedPath<'de>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a borrowed typed path")
+    }
+
+    fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(TypedPath::derive(v))
+    }
+
+    fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(TypedPath::derive(v))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de: 'a, 'a> Deserialize<'de> for TypedPath<'a> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(TypedPathVisitor)
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests {
+    use crate::TypedPath;
+
+    #[test]
+    fn serialize_unix() {
+        let path = TypedPath::unix("/tmp");
+
+        assert_eq!(serde_json::to_string(&path).unwrap(), r#""/tmp""#);
+    }
+
+    #[test]
+    fn serialize_windows() {
+        let path = TypedPath::windows(r"C:\tmp");
+
+        assert_eq!(serde_json::to_string(&path).unwrap(), r#""C:\\tmp""#);
+    }
+
+    #[test]
+    fn deserialize_unix_str() {
+        let path: TypedPath<'_> = serde_json::from_str(r#""/tmp""#).unwrap();
+
+        assert!(path.is_unix());
+        assert_eq!(path, TypedPath::unix("/tmp"));
+    }
+
+    #[test]
+    fn deserialize_unix_bytes() {
+        let path: TypedPath<'_> = serde_json::from_slice(br#""/tmp""#).unwrap();
+
+        assert!(path.is_unix());
+        assert_eq!(path, TypedPath::unix("/tmp"));
+    }
+
+    #[test]
+    fn deserialize_root_windows_path() {
+        // Windows paths can't be borrowed from JSON since the backslashes need to be unescaped
+        assert!(serde_json::from_str::<TypedPath<'_>>(r#""\\some\\path\\to\\file.txt""#).is_err());
     }
 }

--- a/src/typed/non_utf8/pathbuf.rs
+++ b/src/typed/non_utf8/pathbuf.rs
@@ -1,10 +1,15 @@
 use alloc::borrow::Cow;
 use alloc::collections::TryReserveError;
 use core::convert::TryFrom;
+#[cfg(feature = "serde")]
+use core::fmt;
 #[cfg(all(feature = "std", not(target_family = "wasm")))]
 use std::io;
 #[cfg(feature = "std")]
 use std::path::PathBuf;
+
+#[cfg(feature = "serde")]
+use serde_core::{de, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::common::{CheckedPathError, StripPrefixError};
 use crate::no_std_compat::*;
@@ -1110,5 +1115,123 @@ impl TryFrom<TypedPathBuf> for PathBuf {
 impl PartialEq<TypedPath<'_>> for TypedPathBuf {
     fn eq(&self, path: &TypedPath<'_>) -> bool {
         path.eq(&self.to_path())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for TypedPathBuf {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Unix(unix_path) => unix_path.serialize(serializer),
+            Self::Windows(windows_path) => windows_path.serialize(serializer),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+struct TypedPathBufVisitor;
+
+#[cfg(feature = "serde")]
+impl<'de> Visitor<'de> for TypedPathBufVisitor {
+    type Value = TypedPathBuf;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("typed path string")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(TypedPathBuf::from(v))
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(TypedPathBuf::from(v))
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        str::from_utf8(v)
+            .map(TypedPathBuf::from)
+            .map_err(|_| de::Error::invalid_value(de::Unexpected::Bytes(v), &self))
+    }
+
+    fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        String::from_utf8(v)
+            .map(TypedPathBuf::from)
+            .map_err(|e| de::Error::invalid_value(de::Unexpected::Bytes(&e.into_bytes()), &self))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for TypedPathBuf {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_string(TypedPathBufVisitor)
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests {
+    use crate::{TypedPath, TypedPathBuf};
+
+    #[test]
+    fn serialize_unix() {
+        let path = TypedPathBuf::from_unix("/tmp");
+
+        assert_eq!(serde_json::to_string(&path).unwrap(), r#""/tmp""#);
+    }
+
+    #[test]
+    fn serialize_windows() {
+        let path = TypedPathBuf::from_windows(r"C:\tmp");
+
+        assert_eq!(serde_json::to_string(&path).unwrap(), r#""C:\\tmp""#);
+    }
+
+    #[test]
+    fn deserialize_unix_str() {
+        let path = serde_json::from_str::<TypedPathBuf>(r#""/tmp""#).unwrap();
+
+        assert!(path.is_unix());
+        assert_eq!(path, TypedPath::unix("/tmp"));
+    }
+
+    #[test]
+    fn deserialize_unix_bytes() {
+        let path = serde_json::from_slice::<TypedPathBuf>(br#""/tmp""#).unwrap();
+
+        assert!(path.is_unix());
+        assert_eq!(path, TypedPath::unix("/tmp"));
+    }
+
+    #[test]
+    fn deserialize_prefixed_windows_path() {
+        let path = serde_json::from_str::<TypedPathBuf>(r#""C:\\tmp""#).unwrap();
+
+        assert!(path.is_windows());
+        assert_eq!(path, TypedPath::windows(r"C:\tmp"));
+    }
+
+    #[test]
+    fn deserialize_root_windows_path() {
+        let path = serde_json::from_str::<TypedPathBuf>(r#""\\some\\path\\to\\file.txt""#).unwrap();
+
+        assert!(path.is_windows());
+        assert_eq!(path, TypedPath::windows(r"\some\path\to\file.txt"));
     }
 }

--- a/src/typed/non_utf8/pathbuf.rs
+++ b/src/typed/non_utf8/pathbuf.rs
@@ -1160,7 +1160,7 @@ impl<'de> Visitor<'de> for TypedPathBufVisitor {
     where
         E: de::Error,
     {
-        str::from_utf8(v)
+        core::str::from_utf8(v)
             .map(TypedPathBuf::from)
             .map_err(|_| de::Error::invalid_value(de::Unexpected::Bytes(v), &self))
     }

--- a/src/typed/utf8/path.rs
+++ b/src/typed/utf8/path.rs
@@ -838,7 +838,7 @@ impl<'de> Visitor<'de> for Utf8TypedPathVisitor {
     where
         E: de::Error,
     {
-        str::from_utf8(v)
+        core::str::from_utf8(v)
             .map(Utf8TypedPath::derive)
             .map_err(|_| de::Error::invalid_value(Unexpected::Bytes(v), &self))
     }

--- a/src/typed/utf8/path.rs
+++ b/src/typed/utf8/path.rs
@@ -1,5 +1,12 @@
 use core::fmt;
 
+#[cfg(feature = "serde")]
+use serde_core::{
+    de,
+    de::{Unexpected, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+
 use crate::common::{CheckedPathError, StripPrefixError, TryAsRef};
 use crate::typed::{
     PathType, Utf8TypedAncestors, Utf8TypedComponents, Utf8TypedIter, Utf8TypedPathBuf,
@@ -793,5 +800,99 @@ impl<'a> PartialEq<&'a str> for Utf8TypedPath<'_> {
 impl PartialEq<Utf8TypedPath<'_>> for &str {
     fn eq(&self, path: &Utf8TypedPath<'_>) -> bool {
         *self == path.as_str()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for Utf8TypedPath<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Unix(unix_path) => unix_path.serialize(serializer),
+            Self::Windows(windows_path) => windows_path.serialize(serializer),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+struct Utf8TypedPathVisitor;
+
+#[cfg(feature = "serde")]
+impl<'de> Visitor<'de> for Utf8TypedPathVisitor {
+    type Value = Utf8TypedPath<'de>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a borrowed UTF-8 typed path")
+    }
+
+    fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Utf8TypedPath::derive(v))
+    }
+
+    fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        str::from_utf8(v)
+            .map(Utf8TypedPath::derive)
+            .map_err(|_| de::Error::invalid_value(Unexpected::Bytes(v), &self))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de: 'a, 'a> Deserialize<'de> for Utf8TypedPath<'a> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(Utf8TypedPathVisitor)
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests {
+    use crate::Utf8TypedPath;
+
+    #[test]
+    fn serialize_unix() {
+        let path = Utf8TypedPath::unix("/tmp");
+
+        assert_eq!(serde_json::to_string(&path).unwrap(), r#""/tmp""#);
+    }
+
+    #[test]
+    fn serialize_windows() {
+        let path = Utf8TypedPath::windows(r"C:\tmp");
+
+        assert_eq!(serde_json::to_string(&path).unwrap(), r#""C:\\tmp""#);
+    }
+
+    #[test]
+    fn deserialize_unix_str() {
+        let path: Utf8TypedPath<'_> = serde_json::from_str(r#""/tmp""#).unwrap();
+
+        assert!(path.is_unix());
+        assert_eq!(path, Utf8TypedPath::unix("/tmp"));
+    }
+
+    #[test]
+    fn deserialize_unix_bytes() {
+        let path: Utf8TypedPath<'_> = serde_json::from_slice(br#""/tmp""#).unwrap();
+
+        assert!(path.is_unix());
+        assert_eq!(path, Utf8TypedPath::unix("/tmp"));
+    }
+
+    #[test]
+    fn deserialize_root_windows_path() {
+        // Windows paths can't be borrowed from JSON since the backslashes need to be unescaped
+        assert!(
+            serde_json::from_str::<Utf8TypedPath<'_>>(r#""\\some\\path\\to\\file.txt""#).is_err()
+        );
     }
 }

--- a/src/typed/utf8/pathbuf.rs
+++ b/src/typed/utf8/pathbuf.rs
@@ -2,6 +2,9 @@ use alloc::collections::TryReserveError;
 use core::convert::TryFrom;
 use core::fmt;
 
+#[cfg(feature = "serde")]
+use serde_core::{de, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+
 use crate::common::{CheckedPathError, StripPrefixError};
 use crate::no_std_compat::*;
 use crate::typed::{
@@ -1072,5 +1075,124 @@ impl<'a> PartialEq<&'a str> for Utf8TypedPathBuf {
 impl PartialEq<Utf8TypedPathBuf> for &str {
     fn eq(&self, path: &Utf8TypedPathBuf) -> bool {
         *self == path.as_str()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for Utf8TypedPathBuf {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Unix(unix_path) => unix_path.serialize(serializer),
+            Self::Windows(windows_path) => windows_path.serialize(serializer),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+struct Utf8TypedPathBufVisitor;
+
+#[cfg(feature = "serde")]
+impl<'de> Visitor<'de> for Utf8TypedPathBufVisitor {
+    type Value = Utf8TypedPathBuf;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("UTF-8 typed path string")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Utf8TypedPathBuf::from(v))
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Utf8TypedPathBuf::from(v))
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        str::from_utf8(v)
+            .map(Utf8TypedPathBuf::from)
+            .map_err(|_| de::Error::invalid_value(de::Unexpected::Bytes(v), &self))
+    }
+
+    fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        String::from_utf8(v)
+            .map(Utf8TypedPathBuf::from)
+            .map_err(|e| de::Error::invalid_value(de::Unexpected::Bytes(&e.into_bytes()), &self))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for Utf8TypedPathBuf {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_string(Utf8TypedPathBufVisitor)
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests {
+    use crate::{Utf8TypedPath, Utf8TypedPathBuf};
+
+    #[test]
+    fn serialize_unix() {
+        let path = Utf8TypedPathBuf::from_unix("/tmp");
+
+        assert_eq!(serde_json::to_string(&path).unwrap(), r#""/tmp""#);
+    }
+
+    #[test]
+    fn serialize_windows() {
+        let path = Utf8TypedPathBuf::from_windows(r"C:\tmp");
+
+        assert_eq!(serde_json::to_string(&path).unwrap(), r#""C:\\tmp""#);
+    }
+
+    #[test]
+    fn deserialize_unix_str() {
+        let path = serde_json::from_str::<Utf8TypedPathBuf>(r#""/tmp""#).unwrap();
+
+        assert!(path.is_unix());
+        assert_eq!(path, Utf8TypedPath::unix("/tmp"));
+    }
+
+    #[test]
+    fn deserialize_unix_bytes() {
+        let path = serde_json::from_slice::<Utf8TypedPathBuf>(br#""/tmp""#).unwrap();
+
+        assert!(path.is_unix());
+        assert_eq!(path, Utf8TypedPath::unix("/tmp"));
+    }
+
+    #[test]
+    fn deserialize_prefixed_windows_path() {
+        let path = serde_json::from_str::<Utf8TypedPathBuf>(r#""C:\\tmp""#).unwrap();
+
+        assert!(path.is_windows());
+        assert_eq!(path, Utf8TypedPath::windows(r"C:\tmp"));
+    }
+
+    #[test]
+    fn deserialize_root_windows_path() {
+        let path =
+            serde_json::from_str::<Utf8TypedPathBuf>(r#""\\some\\path\\to\\file.txt""#).unwrap();
+
+        assert!(path.is_windows());
+        assert_eq!(path, Utf8TypedPath::windows(r"\some\path\to\file.txt"));
     }
 }

--- a/src/typed/utf8/pathbuf.rs
+++ b/src/typed/utf8/pathbuf.rs
@@ -1120,7 +1120,7 @@ impl<'de> Visitor<'de> for Utf8TypedPathBufVisitor {
     where
         E: de::Error,
     {
-        str::from_utf8(v)
+        core::str::from_utf8(v)
             .map(Utf8TypedPathBuf::from)
             .map_err(|_| de::Error::invalid_value(de::Unexpected::Bytes(v), &self))
     }


### PR DESCRIPTION
This pull request adds support for [serde](https://github.com/serde-rs/serde) gated behind a `serde` feature.

This uses `serde_core` as recommended in order to be quick to compile since it doesn't rely on any proc macros and can compile in parallel with `serde_derive`.

The actual implementations are effectively the same as what [serde defines](https://docs.rs/serde/latest/serde/trait.Deserialize.html#impl-Deserialize%3C'de%3E-for-PathBuf) for `Path` and `PathBuf` in the standard library.

Resolves #54.